### PR TITLE
Add missing pathchanged signal

### DIFF
--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2014-15 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -525,6 +525,7 @@ void StyleSetAttached::setName(const QString& val)
     }
 
     Q_EMIT nameChanged(mName);
+    Q_EMIT pathChanged(QString::fromStdString(pathToString(mPath)));
   }
 }
 
@@ -551,6 +552,8 @@ void StyleSetAttached::onParentChanged(QQuickItem* pNewParent)
   if (pNewParent != nullptr && pParent != nullptr) {
     mPath = traversePathUp(pParent);
     setupStyle();
+
+    Q_EMIT pathChanged(QString::fromStdString(pathToString(mPath)));
   }
 }
 

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2014-15 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -132,7 +132,7 @@ class StyleSet : public QObject
    * the root of the QML object hierarchy.  The path is mostly useful for
    * debugging purposes.
    */
-  Q_PROPERTY(QString path READ path)
+  Q_PROPERTY(QString path READ path NOTIFY pathChanged)
 
   /*! @public Contains the style properties for the element this StyleSet is
    * attached to
@@ -334,6 +334,13 @@ Q_SIGNALS:
    */
   void propsChanged();
 
+  /*! Fires when the path of the item changes
+   *
+   * Whenever the location of the object his StyleSet is attached to changes
+   * the StyleSet will fire this signal.
+   */
+  void pathChanged(const QString& path);
+
 public Q_SLOTS:
   /*! @cond DOXYGEN_IGNORE */
   void onStyleChanged(int changeCount);
@@ -362,7 +369,7 @@ class StyleSetAttached : public QObject
   Q_OBJECT
 
   Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
-  Q_PROPERTY(QString path READ path)
+  Q_PROPERTY(QString path READ path NOTIFY pathChanged)
   Q_PROPERTY(aqt::stylesheets::StyleSet* props READ props NOTIFY propsChanged)
   Q_PROPERTY(QString styleInfo READ styleInfo NOTIFY propsChanged)
 
@@ -382,6 +389,7 @@ public:
 Q_SIGNALS:
   void propsChanged();
   void nameChanged(const QString& name);
+  void pathChanged(const QString& path);
 
 private Q_SLOTS:
   void onStyleEngineChanged(aqt::stylesheets::StyleEngine* pEngine);


### PR DESCRIPTION
The `path` property was not available for binding in QML so far, which probably was overlooked in the first version.