### PR TITLE
Avoid misleading hierarchy warnings

### DIFF
--- a/examples/hierarchy-changes/Foo/Bar.qml
+++ b/examples/hierarchy-changes/Foo/Bar.qml
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+pragma Singleton
+
+import QtQuick 2.3
+import Aqt.StyleSheets 1.1
+
+QtObject {
+    property var textValue: StyleSet.props.get("text")
+}

--- a/examples/hierarchy-changes/Foo/qmldir
+++ b/examples/hierarchy-changes/Foo/qmldir
@@ -1,0 +1,3 @@
+module Foo
+
+singleton Bar 1.0 Bar.qml

--- a/examples/hierarchy-changes/Objects.qml
+++ b/examples/hierarchy-changes/Objects.qml
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import QtQuick 2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.1
+
+import Aqt.StyleSheets 1.1
+
+ApplicationWindow {
+    width: 500
+    height: 410
+
+    StyleEngine {
+        id: styleEngine
+        styleSheetSource: "style.css"
+    }
+
+    property var obj: QtObject {
+       StyleSet.name: "foo"
+       property var value: StyleSet.props.get("text")
+    }
+
+    Rectangle {
+        StyleSet.name: "root"
+        anchors.fill: parent
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: obj.value ? obj.value : "N"
+            font.pixelSize: 72
+        }
+    }
+}

--- a/examples/hierarchy-changes/README.md
+++ b/examples/hierarchy-changes/README.md
@@ -1,0 +1,28 @@
+No signals for hierarchy changes
+
+A little test showing that styleset are not listening on hierarchy changes
+of QtObject.  This normally will raise an info logging on the console, but
+not for singletons (because they won't change their hierarchy anyway).
+
+Run this from the checkouts toplevel folder:
+
+```
+  $ cd aqt-stylesheets/
+  $ qmlscene -I qml -I examples/items examples/hierarchy-changes/Objects.qml
+```
+
+You should see an info warning on the console like this:
+
+```
+INFO: Parent to StyleSetAttached is not a QQuickItem but ' QObject_QML_16 '.
+Hierarchy changes for this component won't be detected.
+```
+
+Run:
+
+```
+  $ qmlscene -I qml -I examples/hierarchy-changes examples/hierarchy-changes/Singletons.qml
+  $ qmlscene -I qml -I examples/hierarchy-changes examples/hierarchy-changes/Windows.qml
+```
+
+For the last two cases You should see no info message.

--- a/examples/hierarchy-changes/Singletons.qml
+++ b/examples/hierarchy-changes/Singletons.qml
@@ -1,0 +1,49 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import QtQuick 2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.1
+
+import Aqt.StyleSheets 1.1
+
+import Foo 1.0 as Foo
+
+ApplicationWindow {
+    width: 500
+    height: 410
+
+    StyleEngine {
+        id: styleEngine
+        styleSheetSource: "style.css"
+    }
+
+    Rectangle {
+        StyleSet.name: "root"
+        anchors.fill: parent
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: Foo.Bar.textValue
+            font.pixelSize: 72
+        }
+    }
+}

--- a/examples/hierarchy-changes/Windows.qml
+++ b/examples/hierarchy-changes/Windows.qml
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import QtQuick 2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.1
+
+import Aqt.StyleSheets 1.1
+
+ApplicationWindow {
+    id: root
+    StyleSet.name: "root"
+
+    width: 500
+    height: 410
+
+    property var textValue: StyleSet.props.get("text")
+
+    StyleEngine {
+        id: styleEngine
+        styleSheetSource: "style.css"
+    }
+
+    Rectangle {
+        StyleSet.name: "root"
+        anchors.fill: parent
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: root.textValue
+            font.pixelSize: 72
+        }
+    }
+}

--- a/examples/hierarchy-changes/style.css
+++ b/examples/hierarchy-changes/style.css
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2015 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+Bar, QObject, .root {
+  text: "B";
+}

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -463,7 +463,7 @@ StyleSetAttached::StyleSetAttached(QObject* pParent)
     if (pItem != nullptr) {
       connect(pItem, SIGNAL(parentChanged(QQuickItem*)), this,
               SLOT(onParentChanged(QQuickItem*)));
-    } else {
+    } else if (p->parent() != nullptr) {
       styleSheetsLogInfo() << "Parent to StyleSetAttached is not a QQuickItem but '"
                            << p->metaObject()->className() << "'. "
                            << "Hierarchy changes for this component won't be detected.";


### PR DESCRIPTION
Only warn about missing parent hierarchy changes when parent objects to StyleSets have an (object) parent.  This silences the warning in those common cases where the object is a (QML) singleton or the toplevel window (ApplicationWindow for instance).