### PR TITLE
Support color expressions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,9 +19,12 @@
 # THE SOFTWARE.
 
 add_library(StyleSheetParser
+  Convert.hpp
+  Convert.cpp
   CssParser.cpp
   CssParser.hpp
   Log.hpp
+  Property.hpp
   StyleMatchTree.cpp
   StyleMatchTree.hpp
   Warnings.hpp

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -1,0 +1,409 @@
+/*
+Copyright (c) 2014-15 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "Convert.hpp"
+
+#include "Log.hpp"
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtGui/QColor>
+#include <QtGui/QFont>
+#include <QtQml/QQmlEngine>
+#include <QtQuick/QQuickItem>
+#include <boost/optional.hpp>
+#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant/get.hpp>
+#include <boost/variant/static_visitor.hpp>
+RESTORE_WARNINGS
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+namespace aqt
+{
+namespace stylesheets
+{
+
+namespace
+{
+
+SUPPRESS_WARNINGS
+const std::string kRgbaColorExpr = "rgba";
+const std::string kRgbColorExpr = "rgb";
+const std::string kHslaColorExpr = "hsla";
+const std::string kHslColorExpr = "hsl";
+RESTORE_WARNINGS
+
+/**
+If the first token in the list is a font style token,
+convert it to a font style and remove it from the list.
+*/
+QFont::Style takeFontStyleFromTokenList(QStringList& tokens)
+{
+  static const std::map<QString, QFont::Style> dictionary = {
+    {"italic", QFont::StyleItalic},
+    {"upright", QFont::StyleNormal},
+    {"oblique", QFont::StyleOblique}};
+
+  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
+           ? dictionary.at(tokens.takeFirst())
+           : QFont::StyleNormal;
+}
+
+/**
+If the first token in the list is a capitalization style token,
+convert it to a capitalization style and remove it from the list.
+*/
+QFont::Capitalization takeCapitalizationStyleFromTokenList(QStringList& tokens)
+{
+  static const std::map<QString, QFont::Capitalization> dictionary = {
+    {"mixedcase", QFont::MixedCase},
+    {"alluppercase", QFont::AllUppercase},
+    {"alllowercase", QFont::AllLowercase},
+    {"smallcaps", QFont::SmallCaps},
+    {"capitalize", QFont::Capitalize}};
+
+  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
+           ? dictionary.at(tokens.takeFirst())
+           : QFont::MixedCase;
+}
+
+/**
+If the first token in the list is a font weight token,
+convert it to a font weight and remove it from the list.
+*/
+QFont::Weight takeFontWeightFromTokenList(QStringList& tokens)
+{
+  static const std::map<QString, QFont::Weight> dictionary = {
+    {"light", QFont::Light},
+    {"bold", QFont::Bold},
+    {"demibold", QFont::DemiBold},
+    {"black", QFont::Black},
+    {"regular", QFont::Normal}};
+
+  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
+           ? dictionary.at(tokens.takeFirst())
+           : QFont::Normal;
+}
+
+struct FontSize {
+  int pixelSize = -1;
+  int pointSize = -1;
+};
+
+/**
+If the first token in the list is a font size token,
+convert it to a font size and remove it from the list.
+*/
+FontSize takeFontSizeFromTokenList(QStringList& tokens)
+{
+  FontSize fontSize;
+  if (!tokens.isEmpty()) {
+    const QString sizeStr = tokens.takeFirst();
+
+    if (sizeStr.contains(QRegExp("^\\d+px$"))) {
+      fontSize.pixelSize = sizeStr.split(QRegExp("px")).at(0).toInt();
+    } else if (sizeStr.contains(QRegExp("^\\d+pt$"))) {
+      fontSize.pointSize = sizeStr.split(QRegExp("pt")).at(0).toInt();
+    } else {
+      tokens.prepend(sizeStr);
+    }
+  }
+  return fontSize;
+}
+
+/**
+Extract the font style from the string.
+
+Font declarations must conform to a limited subset of the W3 font spec
+(http://www.w3.org/TR/css3-fonts/#font-prop), see the following:
+
+@code
+// <style> <variant> <weight> <size> <family>
+// e.g.:
+font: "italic smallcaps bold 16px Times New Roman"
+@endcode
+*/
+QFont fontDeclarationToFont(const QString& fontDecl)
+{
+  QStringList tokens = fontDecl.split(QRegExp("\\s* \\s*"), QString::SkipEmptyParts);
+
+  const QFont::Style fontStyle = takeFontStyleFromTokenList(tokens);
+  const QFont::Capitalization capMode = takeCapitalizationStyleFromTokenList(tokens);
+  const QFont::Weight weight = takeFontWeightFromTokenList(tokens);
+  const FontSize size = takeFontSizeFromTokenList(tokens);
+  const QString familyName = tokens.join(' ');
+
+  QFont font(familyName, size.pointSize, weight);
+  if (size.pixelSize > 0) {
+    font.setPixelSize(size.pixelSize);
+  }
+  font.setCapitalization(capMode);
+  font.setStyle(fontStyle);
+  return font;
+}
+
+//----------------------------------------------------------------------------------------
+
+float clampFloat(float val)
+{
+  if (val < 0) {
+    return 0.0f;
+  } else if (val > 1.0f) {
+    return 1.0f;
+  }
+
+  return val;
+}
+
+int clamp8Bit(int val)
+{
+  if (val < 0) {
+    return 0;
+  } else if (val > 255) {
+    return 255;
+  }
+
+  return val;
+}
+int rgbColorOrPercentage(const std::string& arg)
+{
+  if (!arg.empty()) {
+    try {
+      if (arg.back() == '%') {
+        auto factor = std::stof(arg.substr(0, arg.size() - 1));
+        return clamp8Bit(int(std::round(255 * factor / 100.0f)));
+      } else {
+        return clamp8Bit(std::stoi(arg));
+      }
+    } catch (const std::invalid_argument&) {
+    } catch (const std::out_of_range&) {
+    }
+  }
+
+  return 0;
+}
+
+int transformAlphaFromFloatRatio(const std::string& arg)
+{
+  if (!arg.empty()) {
+    try {
+      auto factor = std::stof(arg);
+      return clamp8Bit(int(std::round(256 * factor)));
+    } catch (const std::invalid_argument&) {
+    } catch (const std::out_of_range&) {
+    }
+  }
+
+  return 0;
+}
+
+float hslHue(const std::string& arg)
+{
+  if (!arg.empty()) {
+    try {
+      return clampFloat(std::stoi(arg) / 360.0f);
+    } catch (const std::invalid_argument&) {
+    } catch (const std::out_of_range&) {
+    }
+  }
+  return 0.0f;
+}
+
+float percentageToFactor(const std::string& arg)
+{
+  if (!arg.empty()) {
+    try {
+      if (arg.back() == '%') {
+        return clampFloat(std::stoi(arg.substr(0, arg.size() - 1)) / 100.0f);
+      }
+    } catch (const std::invalid_argument&) {
+    } catch (const std::out_of_range&) {
+    }
+  }
+  return 100.0f;
+}
+
+float factorFromFloat(const std::string& arg)
+{
+  if (!arg.empty()) {
+    try {
+      return clampFloat(std::stof(arg));
+    } catch (const std::invalid_argument&) {
+    } catch (const std::out_of_range&) {
+    }
+  }
+  return 0.0f;
+}
+
+boost::optional<QColor> makeRgbaColor(const std::vector<std::string>& args)
+{
+  if (args.size() == 4u) {
+    return QColor(rgbColorOrPercentage(args[0]), rgbColorOrPercentage(args[1]),
+                  rgbColorOrPercentage(args[2]), transformAlphaFromFloatRatio(args[3]));
+  } else {
+    styleSheetsLogWarning() << kRgbaColorExpr << "() expression expects 4 arguments";
+  }
+  return boost::none;
+}
+
+boost::optional<QColor> makeRgbColor(const std::vector<std::string>& args)
+{
+  if (args.size() == 3u) {
+    return QColor(rgbColorOrPercentage(args[0]), rgbColorOrPercentage(args[1]),
+                  rgbColorOrPercentage(args[2]), 0xff);
+  } else {
+    styleSheetsLogWarning() << kRgbColorExpr << "() expression expects 3 arguments";
+  }
+  return boost::none;
+}
+
+boost::optional<QColor> makeHslaColor(const std::vector<std::string>& args)
+{
+  if (args.size() == 4u) {
+    QColor color;
+    color.setHslF(hslHue(args[0]), percentageToFactor(args[1]),
+                  percentageToFactor(args[2]), factorFromFloat(args[3]));
+    return color;
+  } else {
+    styleSheetsLogWarning() << kHslaColorExpr << "() expression expects 3 arguments";
+  }
+  return boost::none;
+}
+
+boost::optional<QColor> makeHslColor(const std::vector<std::string>& args)
+{
+  if (args.size() == 3u) {
+    QColor color;
+    color.setHslF(
+      hslHue(args[0]), percentageToFactor(args[1]), percentageToFactor(args[2]), 1.0f);
+    return color;
+  } else {
+    styleSheetsLogWarning() << kHslColorExpr << "() expression expects 3 arguments";
+  }
+  return boost::none;
+}
+
+struct PropValueVisitor : public boost::static_visitor<boost::optional<QColor>> {
+  boost::optional<QColor> operator()(const std::string& value)
+  {
+    auto qvalue = QVariant(QString::fromStdString(value));
+    if (qvalue.canConvert(QMetaType::QColor)) {
+      return qvalue.value<QColor>();
+    }
+    return boost::none;
+  }
+
+  boost::optional<QColor> operator()(const Expression& expr)
+  {
+    using ExprEvaluator =
+      std::function<boost::optional<QColor>(const std::vector<std::string>&)>;
+    using FuncMap = std::unordered_map<std::string, ExprEvaluator>;
+
+    static FuncMap funcMap = {
+      {kRgbaColorExpr, &makeRgbaColor},
+      {kRgbColorExpr, &makeRgbColor},
+      {kHslaColorExpr, &makeHslaColor},
+      {kHslColorExpr, &makeHslColor},
+    };
+
+    auto iFind = funcMap.find(expr.name);
+    if (iFind != funcMap.end()) {
+      return iFind->second(expr.args);
+    } else {
+      styleSheetsLogWarning() << "Unsupported expression '" << expr.name << "'";
+    }
+
+    return boost::none;
+  }
+};
+
+} // anon namespace
+
+//------------------------------------------------------------------------------
+
+boost::optional<QFont> PropertyValueConvertTraits<QFont>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    QVariant qvalue = QVariant::fromValue(QString::fromStdString(*str));
+
+    if (qvalue.canConvert(QMetaType::QString)) {
+      return fontDeclarationToFont(qvalue.toString());
+    }
+  }
+  return boost::none;
+}
+
+
+boost::optional<QColor> PropertyValueConvertTraits<QColor>::convert(
+  const PropertyValue& value) const
+{
+  PropValueVisitor visitor;
+  return boost::apply_visitor(visitor, value);
+}
+
+
+boost::optional<QString> PropertyValueConvertTraits<QString>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    return QString::fromStdString(*str);
+  }
+
+  return boost::none;
+}
+
+
+boost::optional<double> PropertyValueConvertTraits<double>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    try {
+      return boost::make_optional(std::stod(*str));
+    } catch (const std::invalid_argument&) {
+    } catch (const std::out_of_range&) {
+    }
+  }
+
+  return boost::none;
+}
+
+
+boost::optional<bool> PropertyValueConvertTraits<bool>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    if (*str == "true" || *str == "yes") {
+      return boost::make_optional(true);
+    }
+  }
+
+  return boost::none;
+}
+
+} // namespace stylesheets
+} // namespace aqt

--- a/src/Convert.hpp
+++ b/src/Convert.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2015 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,85 +23,59 @@ THE SOFTWARE.
 #pragma once
 
 #include "Property.hpp"
-
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
 #include <QtCore/QString>
-#include <boost/variant/variant.hpp>
+#include <QtCore/QVariant>
+#include <QtGui/QColor>
+#include <QtGui/QFont>
+#include <QtQml/qqml.h>
+#include <boost/optional.hpp>
 RESTORE_WARNINGS
 
 #include <string>
-#include <vector>
 
-/*! @cond DOXYGEN_IGNORE */
 
 namespace aqt
 {
 namespace stylesheets
 {
 
-using SelectorParts = std::vector<std::string>;
-using Selector = std::vector<SelectorParts>;
+/*! @cond DOXYGEN_IGNORE */
+template <typename T>
+struct PropertyValueConvertTraits;
 
-class Propset
-{
-public:
-  std::vector<Selector> selectors;
-  std::vector<Property> properties;
-  LocInfo locInfo;
+template <>
+struct PropertyValueConvertTraits<QFont> {
+  boost::optional<QFont> convert(const PropertyValue& value) const;
 };
 
-class FontFaceDecl
-{
-public:
-  std::string url;
+template <>
+struct PropertyValueConvertTraits<QColor> {
+  boost::optional<QColor> convert(const PropertyValue& value) const;
 };
 
-class StyleSheet
-{
-public:
-  std::vector<Propset> propsets;
-  std::vector<FontFaceDecl> fontfaces;
+template <>
+struct PropertyValueConvertTraits<QString> {
+  boost::optional<QString> convert(const PropertyValue& value) const;
 };
 
-class ParseException
-{
-public:
-  ParseException(const std::string& msg, const std::string& errorContext = "")
-    : mMsg(msg)
-    , mErrorContext(errorContext)
-  {
-  }
-
-  std::string message() const
-  {
-    return mMsg;
-  }
-  std::string errorContext() const
-  {
-    return mErrorContext;
-  }
-
-private:
-  std::string mMsg;
-  std::string mErrorContext;
+template <>
+struct PropertyValueConvertTraits<double> {
+  boost::optional<double> convert(const PropertyValue& value) const;
 };
 
-StyleSheet parseStdString(const std::string& data);
-StyleSheet parseString(const QString& path);
+template <>
+struct PropertyValueConvertTraits<bool> {
+  boost::optional<bool> convert(const PropertyValue& value) const;
+};
 
-/*! Read and parse the style sheet file from @path
- *
- * @return the parsed style sheet
- *
- * @throw std::ios_base::failure exception on IO error or if the file at @path
- *        can not be opened.
- * @throw ParseException when the stylesheet could not be parsed
- */
-StyleSheet parseStyleFile(const QString& path);
+template <typename T, typename Traits = PropertyValueConvertTraits<T>>
+boost::optional<T> convertProperty(const PropertyValue& value, Traits traits = Traits())
+{
+  return traits.convert(value);
+}
 
 } // namespace stylesheets
 } // namespace aqt
-
-/*! @endcond */

--- a/src/CssParser.cpp
+++ b/src/CssParser.cpp
@@ -80,6 +80,12 @@ BOOST_FUSION_ADAPT_STRUCT(
   (std::vector<aqt::stylesheets::Propset>, propsets)
   (std::vector<aqt::stylesheets::FontFaceDecl>, fontfaces)
   )
+
+BOOST_FUSION_ADAPT_STRUCT(
+  aqt::stylesheets::Expression,
+  (std::string, name)
+  (std::vector<std::string>, args)
+  )
 // clang-format on
 
 namespace
@@ -150,13 +156,25 @@ struct StyleSheetGrammar
     quoted_string   = lexeme['"' >> +(char_ - '"') >> '"']
                       | lexeme['\'' >> +(char_ - '\'') >> '\''];
     color           = char_('#') >> +(qi::xdigit);
-    number          = +(qi::digit | char_('-') | char_('.'));
-    atom_value      = quoted_string
+    number          = +(qi::digit | char_('-') | char_('.')) >> *char_('%');
+
+    atom_value       = quoted_string
                       | number
                       | color
                       | identifier;
-    values          = atom_value [push_back(_val, _1)]
+
+    args            = atom_value [push_back(_val, _1)]
                       >> *(lit(',') > atom_value [push_back(_val, _1)]);
+    expression      = identifier[at_c<0>(_val) = _1]
+                      >> lit('(') >> *(args[at_c<1>(_val) = _1]) >> lit(')');
+
+    value           = quoted_string
+                      | number
+                      | color
+                      | expression
+                      | identifier;
+    values          = value [push_back(_val, _1)]
+                      >> *(lit(',') > value [push_back(_val, _1)]);
 
     value_pair      = identifier[at_c<0>(_val) = _1]
                       >> lit(':') >> values[at_c<1>(_val) = _1]
@@ -200,8 +218,11 @@ struct StyleSheetGrammar
     values.name("value");
     number.name("number");
     atom_value.name("atomic value");
+    value.name("value");
     value_pair.name("key-value-pair");
     child_sel.name("child");
+    args.name("args");
+    expression.name("expression");
 
     on_success(propset, locationAnnotator(_val, _1));
     on_success(value_pair, locationAnnotator(_val, _1));
@@ -222,10 +243,13 @@ struct StyleSheetGrammar
   qi::rule<Iterator, std::string(), ascii::space_type> quoted_string;
   qi::rule<Iterator, aqt::stylesheets::Property(), ascii::space_type> value_pair;
   qi::rule<Iterator, std::string(), ascii::space_type> atom_value;
+  qi::rule<Iterator, aqt::stylesheets::PropertyValue(), ascii::space_type> value;
   qi::rule<Iterator, aqt::stylesheets::PropValues(), ascii::space_type> values;
+  qi::rule<Iterator, std::vector<std::string>(), ascii::space_type> args;
   qi::rule<Iterator, aqt::stylesheets::Propset(), ascii::space_type> propset;
   qi::rule<Iterator, aqt::stylesheets::FontFaceDecl(), ascii::space_type> fontfacedecl;
   qi::rule<Iterator, aqt::stylesheets::StyleSheet(), ascii::space_type> stylesheet;
+  qi::rule<Iterator, aqt::stylesheets::Expression(), ascii::space_type> expression;
 
   qi::rule<Iterator, boost::spirit::unused_type> cpp_comment;
   qi::rule<Iterator, boost::spirit::unused_type> c_comment;

--- a/src/CssParser.hpp
+++ b/src/CssParser.hpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 SUPPRESS_WARNINGS
 #include <QtCore/QString>
+#include <boost/variant/variant.hpp>
 RESTORE_WARNINGS
 
 #include <string>
@@ -38,7 +39,15 @@ namespace aqt
 namespace stylesheets
 {
 
-using PropValues = std::vector<std::string>;
+class Expression
+{
+public:
+  std::string name;
+  std::vector<std::string> args;
+};
+
+using PropertyValue = boost::variant<std::string, Expression>;
+using PropValues = std::vector<PropertyValue>;
 using SelectorParts = std::vector<std::string>;
 using Selector = std::vector<SelectorParts>;
 
@@ -56,6 +65,7 @@ public:
   int line;
   int column;
 };
+
 
 class Property
 {

--- a/src/Property.hpp
+++ b/src/Property.hpp
@@ -22,12 +22,9 @@ THE SOFTWARE.
 
 #pragma once
 
-#include "Property.hpp"
-
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
-#include <QtCore/QString>
 #include <boost/variant/variant.hpp>
 RESTORE_WARNINGS
 
@@ -41,65 +38,38 @@ namespace aqt
 namespace stylesheets
 {
 
-using SelectorParts = std::vector<std::string>;
-using Selector = std::vector<SelectorParts>;
-
-class Propset
+class Expression
 {
 public:
-  std::vector<Selector> selectors;
-  std::vector<Property> properties;
+  std::string name;
+  std::vector<std::string> args;
+};
+
+using PropertyValue = boost::variant<std::string, Expression>;
+using PropValues = std::vector<PropertyValue>;
+
+class LocInfo
+{
+public:
+  LocInfo()
+    : byteofs(0)
+    , line(0)
+    , column(0)
+  {
+  }
+
+  int byteofs;
+  int line;
+  int column;
+};
+
+class Property
+{
+public:
+  std::string name;
+  PropValues values;
   LocInfo locInfo;
 };
-
-class FontFaceDecl
-{
-public:
-  std::string url;
-};
-
-class StyleSheet
-{
-public:
-  std::vector<Propset> propsets;
-  std::vector<FontFaceDecl> fontfaces;
-};
-
-class ParseException
-{
-public:
-  ParseException(const std::string& msg, const std::string& errorContext = "")
-    : mMsg(msg)
-    , mErrorContext(errorContext)
-  {
-  }
-
-  std::string message() const
-  {
-    return mMsg;
-  }
-  std::string errorContext() const
-  {
-    return mErrorContext;
-  }
-
-private:
-  std::string mMsg;
-  std::string mErrorContext;
-};
-
-StyleSheet parseStdString(const std::string& data);
-StyleSheet parseString(const QString& path);
-
-/*! Read and parse the style sheet file from @path
- *
- * @return the parsed style sheet
- *
- * @throw std::ios_base::failure exception on IO error or if the file at @path
- *        can not be opened.
- * @throw ParseException when the stylesheet could not be parsed
- */
-StyleSheet parseStyleFile(const QString& path);
 
 } // namespace stylesheets
 } // namespace aqt

--- a/src/StyleMatchTree.cpp
+++ b/src/StyleMatchTree.cpp
@@ -45,18 +45,13 @@ using namespace aqt::stylesheets;
 namespace
 {
 
-struct PredefinedStrings {
-  const std::string descendantAxisId = std::string("::desc::");
-  const std::string conjunctionIndicator = std::string("&");
-  const std::string childIndicator = std::string(">");
-  const std::string dot = std::string(".");
-};
+SUPPRESS_WARNINGS
+const std::string kDescendantAxisId = "::desc::";
+const std::string kConjunctionIndicator = "&";
+const std::string kChildIndicator = ">";
+const std::string kDot = ".";
+RESTORE_WARNINGS
 
-const PredefinedStrings& predefinedStrings()
-{
-  static PredefinedStrings keys;
-  return keys;
-}
 
 QVariantList stdStringListToVariantList(const std::vector<std::string>& vec)
 {
@@ -125,20 +120,20 @@ std::vector<std::string> transformSelector(
   for (auto sel : selector) {
     is_conjunction = false;
     for (auto selPart : sel) {
-      if (selPart == predefinedStrings().childIndicator) {
+      if (selPart == kChildIndicator) {
         // skip
         last_was_symbol = false;
       } else {
         if (!is_conjunction) {
           if (last_was_symbol) {
-            result.push_back(predefinedStrings().descendantAxisId);
+            result.push_back(kDescendantAxisId);
             result.push_back(selPart);
           } else {
             result.push_back(selPart);
             last_was_symbol = true;
           }
         } else {
-          result.push_back(predefinedStrings().conjunctionIndicator);
+          result.push_back(kConjunctionIndicator);
           result.push_back(selPart);
           last_was_symbol = true;
         }
@@ -339,7 +334,7 @@ MatchRec findPathElement(MatchResult& result,
     findPattern(result, Specificity(specificity, 0, 1), node, pathElt.mTypeName);
 
   for (const auto& className : pathElt.mClassNames) {
-    std::string dotName(predefinedStrings().dot + className);
+    std::string dotName(kDot + className);
     auto m2 = findPattern(result, Specificity(specificity, 1, 0), node, dotName);
     matchRec += m2;
   }
@@ -365,8 +360,7 @@ void iterateOverMatches(MatchResult& result,
                         UiItemPath::const_reverse_iterator pathEltEnd)
 {
   auto tryToMatchConjunction = [&](Specificity specificity, const MatchNode* node) {
-    auto m =
-      findPattern(result, specificity, node, predefinedStrings().conjunctionIndicator);
+    auto m = findPattern(result, specificity, node, kConjunctionIndicator);
     for (const auto& tup : m.pNodes) {
       findMatchOnNode(result, getMatchRecSpecificity(tup), getMatchRecNode(tup), pathElt,
                       nextEltIter, pathEltEnd);
@@ -382,8 +376,7 @@ void iterateOverMatches(MatchResult& result,
 
   auto tryToMatchDescendant = [&](Specificity specificity, const MatchNode* node) {
     if (nextEltIter != pathEltEnd) {
-      auto m =
-        findPattern(result, specificity, node, predefinedStrings().descendantAxisId);
+      auto m = findPattern(result, specificity, node, kDescendantAxisId);
       for (const auto& tup : m.pNodes) {
         findDescendantMatchOnNode(result, getMatchRecSpecificity(tup),
                                   getMatchRecNode(tup), *nextEltIter,

--- a/src/StyleMatchTree.hpp
+++ b/src/StyleMatchTree.hpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #pragma once
 
 #include "CssParser.hpp"
+#include "Property.hpp"
 
 #include "estd/memory.hpp"
 #include "Warnings.hpp"
@@ -72,14 +73,14 @@ public:
 class PropertyDef
 {
 public:
-  PropertyDef(const SourceLocation& loc, const QVariant& value)
+  PropertyDef(const SourceLocation& loc, const PropValues& values)
     : mSourceLoc(loc)
-    , mValue(value)
+    , mValues(values)
   {
   }
 
   SourceLocation mSourceLoc;
-  QVariant mValue;
+  PropValues mValues;
 };
 
 using PropertyDefMap = std::unordered_map<std::string, PropertyDef>;
@@ -204,7 +205,7 @@ using UiItemPath = std::vector<PathElement>;
 std::ostream& operator<<(std::ostream& os, const UiItemPath& path);
 std::string pathToString(const UiItemPath& path);
 
-using PropertyMap = std::map<QString, QVariant>;
+using PropertyMap = std::map<QString, PropValues>;
 
 #if defined(DEBUG)
 void dumpPropertyMap(const PropertyMap& properties);

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #include "StyleSet.hpp"
 
+#include "Convert.hpp"
 #include "CssParser.hpp"
 #include "Log.hpp"
 #include "StyleEngine.hpp"
@@ -29,9 +30,11 @@ THE SOFTWARE.
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
+#include <QtGui/QColor>
 #include <QtGui/QFont>
-#include <QtQuick/QQuickItem>
 #include <QtQml/QQmlEngine>
+#include <QtQuick/QQuickItem>
+#include <boost/optional.hpp>
 RESTORE_WARNINGS
 
 #include <iostream>
@@ -173,131 +176,8 @@ PropertyMap effectivePropertyMap(QObject* pObj, int currentChangeCount)
   return traverseParentChain<PropertyMap>(pObj, visitor);
 }
 
-/**
-If the first token in the list is a font style token,
-convert it to a font style and remove it from the list.
-*/
-QFont::Style takeFontStyleFromTokenList(QStringList& tokens)
-{
-  static const std::map<QString, QFont::Style> dictionary = {
-    {"italic", QFont::StyleItalic},
-    {"upright", QFont::StyleNormal},
-    {"oblique", QFont::StyleOblique}};
+} // anon namespace
 
-  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
-           ? dictionary.at(tokens.takeFirst())
-           : QFont::StyleNormal;
-}
-
-/**
-If the first token in the list is a capitalization style token,
-convert it to a capitalization style and remove it from the list.
-*/
-QFont::Capitalization takeCapitalizationStyleFromTokenList(QStringList& tokens)
-{
-  static const std::map<QString, QFont::Capitalization> dictionary = {
-    {"mixedcase", QFont::MixedCase},
-    {"alluppercase", QFont::AllUppercase},
-    {"alllowercase", QFont::AllLowercase},
-    {"smallcaps", QFont::SmallCaps},
-    {"capitalize", QFont::Capitalize}};
-
-  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
-           ? dictionary.at(tokens.takeFirst())
-           : QFont::MixedCase;
-}
-
-/**
-If the first token in the list is a font weight token,
-convert it to a font weight and remove it from the list.
-*/
-QFont::Weight takeFontWeightFromTokenList(QStringList& tokens)
-{
-  static const std::map<QString, QFont::Weight> dictionary = {
-    {"light", QFont::Light},
-    {"bold", QFont::Bold},
-    {"demibold", QFont::DemiBold},
-    {"black", QFont::Black},
-    {"regular", QFont::Normal}};
-
-  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
-           ? dictionary.at(tokens.takeFirst())
-           : QFont::Normal;
-}
-
-struct FontSize {
-  int pixelSize = -1;
-  int pointSize = -1;
-};
-
-/**
-If the first token in the list is a font size token,
-convert it to a font size and remove it from the list.
-*/
-FontSize takeFontSizeFromTokenList(QStringList& tokens)
-{
-  FontSize fontSize;
-  if (!tokens.isEmpty()) {
-    const QString sizeStr = tokens.takeFirst();
-
-    if (sizeStr.contains(QRegExp("^\\d+px$"))) {
-      fontSize.pixelSize = sizeStr.split(QRegExp("px")).at(0).toInt();
-    } else if (sizeStr.contains(QRegExp("^\\d+pt$"))) {
-      fontSize.pointSize = sizeStr.split(QRegExp("pt")).at(0).toInt();
-    } else {
-      tokens.prepend(sizeStr);
-    }
-  }
-  return fontSize;
-}
-
-/**
-Extract the font style from the string.
-
-Font declarations must conform to a limited subset of the W3 font spec
-(http://www.w3.org/TR/css3-fonts/#font-prop), see the following:
-
-@code
-// <style> <variant> <weight> <size> <family>
-// e.g.:
-font: "italic smallcaps bold 16px Times New Roman"
-@endcode
-*/
-QFont fontDeclarationToFont(const QString& fontDecl)
-{
-  QStringList tokens = fontDecl.split(QRegExp("\\s* \\s*"), QString::SkipEmptyParts);
-
-  const QFont::Style fontStyle = takeFontStyleFromTokenList(tokens);
-  const QFont::Capitalization capMode = takeCapitalizationStyleFromTokenList(tokens);
-  const QFont::Weight weight = takeFontWeightFromTokenList(tokens);
-  const FontSize size = takeFontSizeFromTokenList(tokens);
-  const QString familyName = tokens.join(' ');
-
-  QFont font(familyName, size.pointSize, weight);
-  if (size.pixelSize > 0) {
-    font.setPixelSize(size.pixelSize);
-  }
-  font.setCapitalization(capMode);
-  font.setStyle(fontStyle);
-  return font;
-}
-
-struct FontPropertyConvertTraits {
-  const char* typeName() const
-  {
-    return "font";
-  }
-
-  bool convert(QFont& result, QVariant& value) const
-  {
-    if (value.canConvert(QMetaType::QString)) {
-      result = fontDeclarationToFont(value.toString());
-      return true;
-    }
-    return false;
-  }
-};
-}
 
 StyleSet::StyleSet(QObject* pParent)
   : QObject(pParent)
@@ -351,7 +231,7 @@ bool StyleSet::isSet(const QString& key) const
   return mProperties.find(key) != mProperties.end();
 }
 
-bool StyleSet::getImpl(QVariant& value, const QString& key) const
+bool StyleSet::getImpl(PropValues& value, const QString& key) const
 {
   PropertyMap::const_iterator it = mProperties.find(key);
   if (it != mProperties.end()) {
@@ -372,10 +252,34 @@ bool StyleSet::getImpl(QVariant& value, const QString& key) const
 
 QVariant StyleSet::get(const QString& key) const
 {
-  QVariant value;
-  getImpl(value, key);
-  return value;
+  PropValues values;
+  getImpl(values, key);
+
+  if (values.size() == 1) {
+    auto conv = convertProperty<QString>(values[0]);
+    if (conv) {
+      return QVariant::fromValue(*conv);
+    }
+  }
+  else {
+    // TODO.  We should actually check each propValue what would be the best
+    // thing for it to convert, too.  -> Let's make a
+    // convertProperty<QVariantList>() overload which drives a variant
+    // visitor.
+    QVariantList result;
+    for (const auto& propValue : values) {
+      auto conv = convertProperty<QString>(propValue);
+      if (conv) {
+        result.push_back(conv.get());
+      }
+    }
+
+    return result;
+  }
+
+  return QVariant();
 }
+
 
 QColor StyleSet::color(const QString& key) const
 {
@@ -384,7 +288,7 @@ QColor StyleSet::color(const QString& key) const
 
 QFont StyleSet::font(const QString& key) const
 {
-  return lookupProperty<QFont>(key, FontPropertyConvertTraits());
+  return lookupProperty<QFont>(key);
 }
 
 double StyleSet::number(const QString& key) const

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #pragma once
 
+#include "Property.hpp"
 #include "StyleMatchTree.hpp"
 #include "Warnings.hpp"
 
@@ -45,15 +46,6 @@ namespace stylesheets
 
 class StyleEngine;
 class StyleSetAttached;
-
-/*! @cond DOXYGEN_IGNORE */
-namespace detail
-{
-template <typename T>
-struct PropertyConvertTraits;
-}
-
-/*! @endcond */
 
 /*! An attached type used for accessing CSS like style settings
  *
@@ -347,10 +339,10 @@ public Q_SLOTS:
 
 private:
   QObject* grandParent();
-  bool getImpl(QVariant& value, const QString& key) const;
+  bool getImpl(PropValues& value, const QString& key) const;
 
-  template <typename T, typename Traits = detail::PropertyConvertTraits<T>>
-  T lookupProperty(const QString& key, Traits traits = Traits()) const;
+  template <typename T>
+  T lookupProperty(const QString& key) const;
 
 private:
   friend class StyleSetAttached;

--- a/src/test/tst_StyleMatchTree.cpp
+++ b/src/test/tst_StyleMatchTree.cpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #include "StyleMatchTree.hpp"
 
+#include "Convert.hpp"
 #include "CssParser.hpp"
 #include "Warnings.hpp"
 
@@ -29,30 +30,32 @@ SUPPRESS_WARNINGS
 #include <QtCore/QString>
 #include <QtGui/QColor>
 #include <gtest/gtest.h>
+#include <boost/variant/get.hpp>
 RESTORE_WARNINGS
 
 #include <iostream>
 
 //========================================================================================
 
-// This must live outside of any namespace, otherwise C++ won't match QString
-static void PrintTo(const QString& str, ::std::ostream* os)
-{
-  *os << "\"" << str.toStdString() << "\"";
-}
-
 using namespace aqt::stylesheets;
 
 namespace
 {
-QString propertyAsString(PropertyMap pm, const char* pPropertyName)
+std::string propertyAsString(PropertyMap pm, const char* pPropertyName)
 {
-  return pm[QString(pPropertyName)].value<QString>();
+  if (const std::string* str = boost::get<std::string>(&pm[QString(pPropertyName)][0])) {
+    return *str;
+  }
+  return std::string();
 }
 
 QColor propertyAsColor(PropertyMap pm, const char* pPropertyName)
 {
-  return pm[QString(pPropertyName)].value<QColor>();
+  auto result = convertProperty<QColor>(pm[QString(pPropertyName)][0]);
+  if (result) {
+    return *result;
+  }
+  return QColor();
 }
 } // anon namespace
 


### PR DESCRIPTION
@rof-ableton @sbs-ableton

... like `color: hsla(320, 100% 75%, 0.3);` in CSS.  This is probably not the final version. Color functions like this can easily be resolved inside of the StyleMatchTree builder (as it is done here), but expressions like `url('')` wouldn't have enough context.  Those can only be resolved probably in the StyleSet (at lookup time?), but for this we would need to change the PropertyMap representation (which already works in terms of QVariant).  But maybe this is a second step?  What do you think?