### PR TITLE
Support color expressions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Ableton AG, Berlin
+# Copyright (c) 2014-15 Ableton AG, Berlin
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,9 +19,12 @@
 # THE SOFTWARE.
 
 add_library(StyleSheetParser
+  Convert.hpp
+  Convert.cpp
   CssParser.cpp
   CssParser.hpp
   Log.hpp
+  Property.hpp
   StyleMatchTree.cpp
   StyleMatchTree.hpp
   Warnings.hpp

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -58,6 +58,8 @@ const std::string kRgbaColorExpr = "rgba";
 const std::string kRgbColorExpr = "rgb";
 const std::string kHslaColorExpr = "hsla";
 const std::string kHslColorExpr = "hsl";
+const std::string kHsbaColorExpr = "hsba";
+const std::string kHsbColorExpr = "hsb";
 const std::string kTrue = "true";
 const std::string kYes = "yes";
 const std::string kFalse = "false";
@@ -282,6 +284,40 @@ ExprValue makeHslColor(const std::vector<std::string>& args)
   return Undefined();
 }
 
+ExprValue makeHsbaColor(const std::vector<std::string>& args)
+{
+  if (args.size() == 4u) {
+    try {
+      QColor color;
+      color.setHsvF(hslHue(args[0]), percentageToFactor(args[1]),
+                    percentageToFactor(args[2]), factorFromFloat(args[3]));
+      return color;
+    } catch (const boost::bad_lexical_cast&) {
+      styleSheetsLogWarning() << kHslaColorExpr << "() expression with bad values";
+    }
+  } else {
+    styleSheetsLogWarning() << kHslaColorExpr << "() expression expects 3 arguments";
+  }
+  return Undefined();
+}
+
+ExprValue makeHsbColor(const std::vector<std::string>& args)
+{
+  if (args.size() == 3u) {
+    try {
+      QColor color;
+      color.setHsvF(
+        hslHue(args[0]), percentageToFactor(args[1]), percentageToFactor(args[2]), 1.0f);
+      return color;
+    } catch (const boost::bad_lexical_cast&) {
+      styleSheetsLogWarning() << kHslColorExpr << "() expression with bad values";
+    }
+  } else {
+    styleSheetsLogWarning() << kHslColorExpr << "() expression expects 3 arguments";
+  }
+  return Undefined();
+}
+
 //------------------------------------------------------------------------------
 
 ExprValue evaluateExpression(const Expression& expr)
@@ -294,6 +330,8 @@ ExprValue evaluateExpression(const Expression& expr)
     {kRgbColorExpr, &makeRgbColor},
     {kHslaColorExpr, &makeHslaColor},
     {kHslColorExpr, &makeHslColor},
+    {kHsbaColorExpr, &makeHsbaColor},
+    {kHsbColorExpr, &makeHsbColor},
   };
 
   auto iFind = funcMap.find(expr.name);

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -1,0 +1,251 @@
+/*
+Copyright (c) 2014-15 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "Convert.hpp"
+
+#include "Log.hpp"
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtGui/QColor>
+#include <QtGui/QFont>
+#include <QtQml/QQmlEngine>
+#include <QtQuick/QQuickItem>
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/optional.hpp>
+#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant/get.hpp>
+#include <boost/variant/static_visitor.hpp>
+RESTORE_WARNINGS
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+namespace aqt
+{
+namespace stylesheets
+{
+
+namespace
+{
+
+SUPPRESS_WARNINGS
+const std::string kTrue = "true";
+const std::string kYes = "yes";
+const std::string kFalse = "false";
+const std::string kNo = "no";
+RESTORE_WARNINGS
+
+/**
+If the first token in the list is a font style token,
+convert it to a font style and remove it from the list.
+*/
+QFont::Style takeFontStyleFromTokenList(QStringList& tokens)
+{
+  static const std::map<QString, QFont::Style> dictionary = {
+    {"italic", QFont::StyleItalic},
+    {"upright", QFont::StyleNormal},
+    {"oblique", QFont::StyleOblique}};
+
+  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
+           ? dictionary.at(tokens.takeFirst())
+           : QFont::StyleNormal;
+}
+
+/**
+If the first token in the list is a capitalization style token,
+convert it to a capitalization style and remove it from the list.
+*/
+QFont::Capitalization takeCapitalizationStyleFromTokenList(QStringList& tokens)
+{
+  static const std::map<QString, QFont::Capitalization> dictionary = {
+    {"mixedcase", QFont::MixedCase},
+    {"alluppercase", QFont::AllUppercase},
+    {"alllowercase", QFont::AllLowercase},
+    {"smallcaps", QFont::SmallCaps},
+    {"capitalize", QFont::Capitalize}};
+
+  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
+           ? dictionary.at(tokens.takeFirst())
+           : QFont::MixedCase;
+}
+
+/**
+If the first token in the list is a font weight token,
+convert it to a font weight and remove it from the list.
+*/
+QFont::Weight takeFontWeightFromTokenList(QStringList& tokens)
+{
+  static const std::map<QString, QFont::Weight> dictionary = {
+    {"light", QFont::Light},
+    {"bold", QFont::Bold},
+    {"demibold", QFont::DemiBold},
+    {"black", QFont::Black},
+    {"regular", QFont::Normal}};
+
+  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
+           ? dictionary.at(tokens.takeFirst())
+           : QFont::Normal;
+}
+
+struct FontSize {
+  int pixelSize = -1;
+  int pointSize = -1;
+};
+
+/**
+If the first token in the list is a font size token,
+convert it to a font size and remove it from the list.
+*/
+FontSize takeFontSizeFromTokenList(QStringList& tokens)
+{
+  FontSize fontSize;
+  if (!tokens.isEmpty()) {
+    const QString sizeStr = tokens.takeFirst();
+
+    if (sizeStr.contains(QRegExp("^\\d+px$"))) {
+      fontSize.pixelSize = sizeStr.split(QRegExp("px")).at(0).toInt();
+    } else if (sizeStr.contains(QRegExp("^\\d+pt$"))) {
+      fontSize.pointSize = sizeStr.split(QRegExp("pt")).at(0).toInt();
+    } else {
+      tokens.prepend(sizeStr);
+    }
+  }
+  return fontSize;
+}
+
+/**
+Extract the font style from the string.
+
+Font declarations must conform to a limited subset of the W3 font spec
+(http://www.w3.org/TR/css3-fonts/#font-prop), see the following:
+
+@code
+// <style> <variant> <weight> <size> <family>
+// e.g.:
+font: "italic smallcaps bold 16px Times New Roman"
+@endcode
+*/
+QFont fontDeclarationToFont(const QString& fontDecl)
+{
+  QStringList tokens = fontDecl.split(QRegExp("\\s* \\s*"), QString::SkipEmptyParts);
+
+  const QFont::Style fontStyle = takeFontStyleFromTokenList(tokens);
+  const QFont::Capitalization capMode = takeCapitalizationStyleFromTokenList(tokens);
+  const QFont::Weight weight = takeFontWeightFromTokenList(tokens);
+  const FontSize size = takeFontSizeFromTokenList(tokens);
+  const QString familyName = tokens.join(' ');
+
+  QFont font(familyName, size.pointSize, weight);
+  if (size.pixelSize > 0) {
+    font.setPixelSize(size.pixelSize);
+  }
+  font.setCapitalization(capMode);
+  font.setStyle(fontStyle);
+  return font;
+}
+
+struct PropValueVisitor : public boost::static_visitor<boost::optional<QColor>> {
+  boost::optional<QColor> operator()(const std::string& value)
+  {
+    auto qvalue = QVariant(QString::fromStdString(value));
+    if (qvalue.canConvert(QMetaType::QColor)) {
+      return qvalue.value<QColor>();
+    }
+    return boost::none;
+  }
+
+  boost::optional<QColor> operator()(const Expression& expr)
+  {
+    styleSheetsLogWarning() << "Unsupported expression '" << expr.name << "'";
+    return boost::none;
+  }
+};
+
+} // anon namespace
+
+//------------------------------------------------------------------------------
+
+boost::optional<QFont> PropertyValueConvertTraits<QFont>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    QVariant qvalue = QVariant::fromValue(QString::fromStdString(*str));
+
+    if (qvalue.canConvert(QMetaType::QString)) {
+      return fontDeclarationToFont(qvalue.toString());
+    }
+  }
+  return boost::none;
+}
+
+boost::optional<QColor> PropertyValueConvertTraits<QColor>::convert(
+  const PropertyValue& value) const
+{
+  PropValueVisitor visitor;
+  return boost::apply_visitor(visitor, value);
+}
+
+boost::optional<QString> PropertyValueConvertTraits<QString>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    return QString::fromStdString(*str);
+  }
+
+  return boost::none;
+}
+
+boost::optional<double> PropertyValueConvertTraits<double>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    try {
+      return boost::make_optional(std::stod(*str));
+    } catch (const std::invalid_argument&) {
+    } catch (const std::out_of_range&) {
+    }
+  }
+
+  return boost::none;
+}
+
+boost::optional<bool> PropertyValueConvertTraits<bool>::convert(
+  const PropertyValue& value) const
+{
+  if (const std::string* str = boost::get<std::string>(&value)) {
+    auto lstr = boost::algorithm::to_lower_copy(*str);
+    if (lstr == kTrue || lstr == kYes) {
+      return boost::make_optional(true);
+    } else if (lstr == kFalse || lstr == kNo) {
+      return boost::make_optional(false);
+    }
+  }
+
+  return boost::none;
+}
+
+} // namespace stylesheets
+} // namespace aqt

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -117,8 +117,8 @@ QFont::Weight takeFontWeightFromTokenList(QStringList& tokens)
 }
 
 struct FontSize {
-  int pixelSize = -1;
-  int pointSize = -1;
+  int pixelSize = 0;
+  qreal pointSize = 0.0f;
 };
 
 /**
@@ -133,8 +133,8 @@ FontSize takeFontSizeFromTokenList(QStringList& tokens)
 
     if (sizeStr.contains(QRegExp("^\\d+px$"))) {
       fontSize.pixelSize = sizeStr.split(QRegExp("px")).at(0).toInt();
-    } else if (sizeStr.contains(QRegExp("^\\d+pt$"))) {
-      fontSize.pointSize = sizeStr.split(QRegExp("pt")).at(0).toInt();
+    } else if (sizeStr.contains(QRegExp("^\\d+(\\.\\d+)?pt$"))) {
+      fontSize.pointSize = sizeStr.split(QRegExp("pt")).at(0).toDouble();
     } else {
       tokens.prepend(sizeStr);
     }
@@ -164,7 +164,10 @@ QFont fontDeclarationToFont(const QString& fontDecl)
   const FontSize size = takeFontSizeFromTokenList(tokens);
   const QString familyName = tokens.join(' ');
 
-  QFont font(familyName, size.pointSize, weight);
+  QFont font(familyName, 0, weight);
+  if (size.pointSize > 0) {
+    font.setPointSizeF(size.pointSize);
+  }
   if (size.pixelSize > 0) {
     font.setPixelSize(size.pixelSize);
   }

--- a/src/Convert.hpp
+++ b/src/Convert.hpp
@@ -77,5 +77,8 @@ boost::optional<T> convertProperty(const PropertyValue& value, Traits traits = T
   return traits.convert(value);
 }
 
+QVariant convertValueToVariant(const PropertyValue& value);
+QVariantList convertValueToVariantList(const PropValues& values);
+
 } // namespace stylesheets
 } // namespace aqt

--- a/src/Convert.hpp
+++ b/src/Convert.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-15 Ableton AG, Berlin
+Copyright (c) 2015 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,85 +23,59 @@ THE SOFTWARE.
 #pragma once
 
 #include "Property.hpp"
-
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
 #include <QtCore/QString>
-#include <boost/variant/variant.hpp>
+#include <QtCore/QVariant>
+#include <QtGui/QColor>
+#include <QtGui/QFont>
+#include <QtQml/qqml.h>
+#include <boost/optional.hpp>
 RESTORE_WARNINGS
 
 #include <string>
-#include <vector>
 
-/*! @cond DOXYGEN_IGNORE */
 
 namespace aqt
 {
 namespace stylesheets
 {
 
-using SelectorParts = std::vector<std::string>;
-using Selector = std::vector<SelectorParts>;
+/*! @cond DOXYGEN_IGNORE */
+template <typename T>
+struct PropertyValueConvertTraits;
 
-class Propset
-{
-public:
-  std::vector<Selector> selectors;
-  std::vector<Property> properties;
-  LocInfo locInfo;
+template <>
+struct PropertyValueConvertTraits<QFont> {
+  boost::optional<QFont> convert(const PropertyValue& value) const;
 };
 
-class FontFaceDecl
-{
-public:
-  std::string url;
+template <>
+struct PropertyValueConvertTraits<QColor> {
+  boost::optional<QColor> convert(const PropertyValue& value) const;
 };
 
-class StyleSheet
-{
-public:
-  std::vector<Propset> propsets;
-  std::vector<FontFaceDecl> fontfaces;
+template <>
+struct PropertyValueConvertTraits<QString> {
+  boost::optional<QString> convert(const PropertyValue& value) const;
 };
 
-class ParseException
-{
-public:
-  ParseException(const std::string& msg, const std::string& errorContext = "")
-    : mMsg(msg)
-    , mErrorContext(errorContext)
-  {
-  }
-
-  std::string message() const
-  {
-    return mMsg;
-  }
-  std::string errorContext() const
-  {
-    return mErrorContext;
-  }
-
-private:
-  std::string mMsg;
-  std::string mErrorContext;
+template <>
+struct PropertyValueConvertTraits<double> {
+  boost::optional<double> convert(const PropertyValue& value) const;
 };
 
-StyleSheet parseStdString(const std::string& data);
-StyleSheet parseString(const QString& path);
+template <>
+struct PropertyValueConvertTraits<bool> {
+  boost::optional<bool> convert(const PropertyValue& value) const;
+};
 
-/*! Read and parse the style sheet file from @path
- *
- * @return the parsed style sheet
- *
- * @throw std::ios_base::failure exception on IO error or if the file at @path
- *        can not be opened.
- * @throw ParseException when the stylesheet could not be parsed
- */
-StyleSheet parseStyleFile(const QString& path);
+template <typename T, typename Traits = PropertyValueConvertTraits<T>>
+boost::optional<T> convertProperty(const PropertyValue& value, Traits traits = Traits())
+{
+  return traits.convert(value);
+}
 
 } // namespace stylesheets
 } // namespace aqt
-
-/*! @endcond */

--- a/src/CssParser.hpp
+++ b/src/CssParser.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2014-15 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 SUPPRESS_WARNINGS
 #include <QtCore/QString>
+#include <boost/variant/variant.hpp>
 RESTORE_WARNINGS
 
 #include <string>
@@ -38,7 +39,15 @@ namespace aqt
 namespace stylesheets
 {
 
-using PropValues = std::vector<std::string>;
+class Expression
+{
+public:
+  std::string name;
+  std::vector<std::string> args;
+};
+
+using PropertyValue = boost::variant<std::string, Expression>;
+using PropValues = std::vector<PropertyValue>;
 using SelectorParts = std::vector<std::string>;
 using Selector = std::vector<SelectorParts>;
 
@@ -56,6 +65,7 @@ public:
   int line;
   int column;
 };
+
 
 class Property
 {

--- a/src/Property.hpp
+++ b/src/Property.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-15 Ableton AG, Berlin
+Copyright (c) 2015 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,12 +22,9 @@ THE SOFTWARE.
 
 #pragma once
 
-#include "Property.hpp"
-
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
-#include <QtCore/QString>
 #include <boost/variant/variant.hpp>
 RESTORE_WARNINGS
 
@@ -41,65 +38,38 @@ namespace aqt
 namespace stylesheets
 {
 
-using SelectorParts = std::vector<std::string>;
-using Selector = std::vector<SelectorParts>;
-
-class Propset
+class Expression
 {
 public:
-  std::vector<Selector> selectors;
-  std::vector<Property> properties;
+  std::string name;
+  std::vector<std::string> args;
+};
+
+using PropertyValue = boost::variant<std::string, Expression>;
+using PropValues = std::vector<PropertyValue>;
+
+class LocInfo
+{
+public:
+  LocInfo()
+    : byteofs(0)
+    , line(0)
+    , column(0)
+  {
+  }
+
+  int byteofs;
+  int line;
+  int column;
+};
+
+class Property
+{
+public:
+  std::string name;
+  PropValues values;
   LocInfo locInfo;
 };
-
-class FontFaceDecl
-{
-public:
-  std::string url;
-};
-
-class StyleSheet
-{
-public:
-  std::vector<Propset> propsets;
-  std::vector<FontFaceDecl> fontfaces;
-};
-
-class ParseException
-{
-public:
-  ParseException(const std::string& msg, const std::string& errorContext = "")
-    : mMsg(msg)
-    , mErrorContext(errorContext)
-  {
-  }
-
-  std::string message() const
-  {
-    return mMsg;
-  }
-  std::string errorContext() const
-  {
-    return mErrorContext;
-  }
-
-private:
-  std::string mMsg;
-  std::string mErrorContext;
-};
-
-StyleSheet parseStdString(const std::string& data);
-StyleSheet parseString(const QString& path);
-
-/*! Read and parse the style sheet file from @path
- *
- * @return the parsed style sheet
- *
- * @throw std::ios_base::failure exception on IO error or if the file at @path
- *        can not be opened.
- * @throw ParseException when the stylesheet could not be parsed
- */
-StyleSheet parseStyleFile(const QString& path);
 
 } // namespace stylesheets
 } // namespace aqt

--- a/src/StyleMatchTree.cpp
+++ b/src/StyleMatchTree.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2014-15 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -45,18 +45,13 @@ using namespace aqt::stylesheets;
 namespace
 {
 
-struct PredefinedStrings {
-  const std::string descendantAxisId = std::string("::desc::");
-  const std::string conjunctionIndicator = std::string("&");
-  const std::string childIndicator = std::string(">");
-  const std::string dot = std::string(".");
-};
+SUPPRESS_WARNINGS
+const std::string kDescendantAxisId = "::desc::";
+const std::string kConjunctionIndicator = "&";
+const std::string kChildIndicator = ">";
+const std::string kDot = ".";
+RESTORE_WARNINGS
 
-const PredefinedStrings& predefinedStrings()
-{
-  static PredefinedStrings keys;
-  return keys;
-}
 
 QVariantList stdStringListToVariantList(const std::vector<std::string>& vec)
 {
@@ -125,20 +120,20 @@ std::vector<std::string> transformSelector(
   for (auto sel : selector) {
     is_conjunction = false;
     for (auto selPart : sel) {
-      if (selPart == predefinedStrings().childIndicator) {
+      if (selPart == kChildIndicator) {
         // skip
         last_was_symbol = false;
       } else {
         if (!is_conjunction) {
           if (last_was_symbol) {
-            result.push_back(predefinedStrings().descendantAxisId);
+            result.push_back(kDescendantAxisId);
             result.push_back(selPart);
           } else {
             result.push_back(selPart);
             last_was_symbol = true;
           }
         } else {
-          result.push_back(predefinedStrings().conjunctionIndicator);
+          result.push_back(kConjunctionIndicator);
           result.push_back(selPart);
           last_was_symbol = true;
         }
@@ -339,7 +334,7 @@ MatchRec findPathElement(MatchResult& result,
     findPattern(result, Specificity(specificity, 0, 1), node, pathElt.mTypeName);
 
   for (const auto& className : pathElt.mClassNames) {
-    std::string dotName(predefinedStrings().dot + className);
+    std::string dotName(kDot + className);
     auto m2 = findPattern(result, Specificity(specificity, 1, 0), node, dotName);
     matchRec += m2;
   }
@@ -365,8 +360,7 @@ void iterateOverMatches(MatchResult& result,
                         UiItemPath::const_reverse_iterator pathEltEnd)
 {
   auto tryToMatchConjunction = [&](Specificity specificity, const MatchNode* node) {
-    auto m =
-      findPattern(result, specificity, node, predefinedStrings().conjunctionIndicator);
+    auto m = findPattern(result, specificity, node, kConjunctionIndicator);
     for (const auto& tup : m.pNodes) {
       findMatchOnNode(result, getMatchRecSpecificity(tup), getMatchRecNode(tup), pathElt,
                       nextEltIter, pathEltEnd);
@@ -382,8 +376,7 @@ void iterateOverMatches(MatchResult& result,
 
   auto tryToMatchDescendant = [&](Specificity specificity, const MatchNode* node) {
     if (nextEltIter != pathEltEnd) {
-      auto m =
-        findPattern(result, specificity, node, predefinedStrings().descendantAxisId);
+      auto m = findPattern(result, specificity, node, kDescendantAxisId);
       for (const auto& tup : m.pNodes) {
         findDescendantMatchOnNode(result, getMatchRecSpecificity(tup),
                                   getMatchRecNode(tup), *nextEltIter,

--- a/src/StyleMatchTree.hpp
+++ b/src/StyleMatchTree.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2014-15 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #pragma once
 
 #include "CssParser.hpp"
+#include "Property.hpp"
 
 #include "estd/memory.hpp"
 #include "Warnings.hpp"
@@ -72,14 +73,14 @@ public:
 class PropertyDef
 {
 public:
-  PropertyDef(const SourceLocation& loc, const QVariant& value)
+  PropertyDef(const SourceLocation& loc, const PropValues& values)
     : mSourceLoc(loc)
-    , mValue(value)
+    , mValues(values)
   {
   }
 
   SourceLocation mSourceLoc;
-  QVariant mValue;
+  PropValues mValues;
 };
 
 using PropertyDefMap = std::unordered_map<std::string, PropertyDef>;
@@ -204,7 +205,7 @@ using UiItemPath = std::vector<PathElement>;
 std::ostream& operator<<(std::ostream& os, const UiItemPath& path);
 std::string pathToString(const UiItemPath& path);
 
-using PropertyMap = std::map<QString, QVariant>;
+using PropertyMap = std::map<QString, PropValues>;
 
 #if defined(DEBUG)
 void dumpPropertyMap(const PropertyMap& properties);

--- a/src/StylePlugin.cpp
+++ b/src/StylePlugin.cpp
@@ -36,6 +36,8 @@ void aqt::stylesheets::StylePlugin::registerTypes(const char* pUri)
 {
   qmlRegisterUncreatableType<aqt::stylesheets::StyleSet>(
     pUri, 1, 0, "StyleSet", "StyleSet is exposed as an attached property");
+  qmlRegisterUncreatableType<aqt::stylesheets::StyleSet, 2>(
+    pUri, 1, 2, "StyleSet", "StyleSet is exposed as an attached property");
   qmlRegisterType<aqt::stylesheets::StyleEngine>(pUri, 1, 0, "StyleEngine");
   qmlRegisterType<aqt::stylesheets::StyleEngine, 1>(pUri, 1, 1, "StyleEngine");
   qmlRegisterType<aqt::stylesheets::StylesDirWatcher>(pUri, 1, 1, "StylesDirWatcher");

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -306,6 +306,11 @@ bool StyleSet::boolean(const QString& key) const
   return lookupProperty<bool>(key);
 }
 
+QString StyleSet::string(const QString& key) const
+{
+  return lookupProperty<QString>(key);
+}
+
 void StyleSet::onStyleChanged(int changeCount)
 {
   if (mChangeCount != changeCount) {

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -178,7 +178,6 @@ PropertyMap effectivePropertyMap(QObject* pObj, int currentChangeCount)
 
 } // anon namespace
 
-
 StyleSet::StyleSet(QObject* pParent)
   : QObject(pParent)
   , mChangeCount(0)
@@ -260,12 +259,7 @@ QVariant StyleSet::get(const QString& key) const
     if (conv) {
       return QVariant::fromValue(*conv);
     }
-  }
-  else {
-    // TODO.  We should actually check each propValue what would be the best
-    // thing for it to convert, too.  -> Let's make a
-    // convertProperty<QVariantList>() overload which drives a variant
-    // visitor.
+  } else {
     QVariantList result;
     for (const auto& propValue : values) {
       auto conv = convertProperty<QString>(propValue);
@@ -280,6 +274,17 @@ QVariant StyleSet::get(const QString& key) const
   return QVariant();
 }
 
+QVariant StyleSet::values(const QString& key) const
+{
+  PropValues values;
+  getImpl(values, key);
+
+  if (values.size() == 1) {
+    return convertValueToVariant(values[0]);
+  }
+
+  return convertValueToVariantList(values);
+}
 
 QColor StyleSet::color(const QString& key) const
 {

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #include "StyleSet.hpp"
 
+#include "Convert.hpp"
 #include "CssParser.hpp"
 #include "Log.hpp"
 #include "StyleEngine.hpp"
@@ -29,9 +30,11 @@ THE SOFTWARE.
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
+#include <QtGui/QColor>
 #include <QtGui/QFont>
-#include <QtQuick/QQuickItem>
 #include <QtQml/QQmlEngine>
+#include <QtQuick/QQuickItem>
+#include <boost/optional.hpp>
 RESTORE_WARNINGS
 
 #include <iostream>
@@ -173,131 +176,8 @@ PropertyMap effectivePropertyMap(QObject* pObj, int currentChangeCount)
   return traverseParentChain<PropertyMap>(pObj, visitor);
 }
 
-/**
-If the first token in the list is a font style token,
-convert it to a font style and remove it from the list.
-*/
-QFont::Style takeFontStyleFromTokenList(QStringList& tokens)
-{
-  static const std::map<QString, QFont::Style> dictionary = {
-    {"italic", QFont::StyleItalic},
-    {"upright", QFont::StyleNormal},
-    {"oblique", QFont::StyleOblique}};
+} // anon namespace
 
-  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
-           ? dictionary.at(tokens.takeFirst())
-           : QFont::StyleNormal;
-}
-
-/**
-If the first token in the list is a capitalization style token,
-convert it to a capitalization style and remove it from the list.
-*/
-QFont::Capitalization takeCapitalizationStyleFromTokenList(QStringList& tokens)
-{
-  static const std::map<QString, QFont::Capitalization> dictionary = {
-    {"mixedcase", QFont::MixedCase},
-    {"alluppercase", QFont::AllUppercase},
-    {"alllowercase", QFont::AllLowercase},
-    {"smallcaps", QFont::SmallCaps},
-    {"capitalize", QFont::Capitalize}};
-
-  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
-           ? dictionary.at(tokens.takeFirst())
-           : QFont::MixedCase;
-}
-
-/**
-If the first token in the list is a font weight token,
-convert it to a font weight and remove it from the list.
-*/
-QFont::Weight takeFontWeightFromTokenList(QStringList& tokens)
-{
-  static const std::map<QString, QFont::Weight> dictionary = {
-    {"light", QFont::Light},
-    {"bold", QFont::Bold},
-    {"demibold", QFont::DemiBold},
-    {"black", QFont::Black},
-    {"regular", QFont::Normal}};
-
-  return (!tokens.isEmpty() && dictionary.count(tokens.at(0)))
-           ? dictionary.at(tokens.takeFirst())
-           : QFont::Normal;
-}
-
-struct FontSize {
-  int pixelSize = -1;
-  int pointSize = -1;
-};
-
-/**
-If the first token in the list is a font size token,
-convert it to a font size and remove it from the list.
-*/
-FontSize takeFontSizeFromTokenList(QStringList& tokens)
-{
-  FontSize fontSize;
-  if (!tokens.isEmpty()) {
-    const QString sizeStr = tokens.takeFirst();
-
-    if (sizeStr.contains(QRegExp("^\\d+px$"))) {
-      fontSize.pixelSize = sizeStr.split(QRegExp("px")).at(0).toInt();
-    } else if (sizeStr.contains(QRegExp("^\\d+pt$"))) {
-      fontSize.pointSize = sizeStr.split(QRegExp("pt")).at(0).toInt();
-    } else {
-      tokens.prepend(sizeStr);
-    }
-  }
-  return fontSize;
-}
-
-/**
-Extract the font style from the string.
-
-Font declarations must conform to a limited subset of the W3 font spec
-(http://www.w3.org/TR/css3-fonts/#font-prop), see the following:
-
-@code
-// <style> <variant> <weight> <size> <family>
-// e.g.:
-font: "italic smallcaps bold 16px Times New Roman"
-@endcode
-*/
-QFont fontDeclarationToFont(const QString& fontDecl)
-{
-  QStringList tokens = fontDecl.split(QRegExp("\\s* \\s*"), QString::SkipEmptyParts);
-
-  const QFont::Style fontStyle = takeFontStyleFromTokenList(tokens);
-  const QFont::Capitalization capMode = takeCapitalizationStyleFromTokenList(tokens);
-  const QFont::Weight weight = takeFontWeightFromTokenList(tokens);
-  const FontSize size = takeFontSizeFromTokenList(tokens);
-  const QString familyName = tokens.join(' ');
-
-  QFont font(familyName, size.pointSize, weight);
-  if (size.pixelSize > 0) {
-    font.setPixelSize(size.pixelSize);
-  }
-  font.setCapitalization(capMode);
-  font.setStyle(fontStyle);
-  return font;
-}
-
-struct FontPropertyConvertTraits {
-  const char* typeName() const
-  {
-    return "font";
-  }
-
-  bool convert(QFont& result, QVariant& value) const
-  {
-    if (value.canConvert(QMetaType::QString)) {
-      result = fontDeclarationToFont(value.toString());
-      return true;
-    }
-    return false;
-  }
-};
-}
 
 StyleSet::StyleSet(QObject* pParent)
   : QObject(pParent)
@@ -351,7 +231,7 @@ bool StyleSet::isSet(const QString& key) const
   return mProperties.find(key) != mProperties.end();
 }
 
-bool StyleSet::getImpl(QVariant& value, const QString& key) const
+bool StyleSet::getImpl(PropValues& value, const QString& key) const
 {
   PropertyMap::const_iterator it = mProperties.find(key);
   if (it != mProperties.end()) {
@@ -372,10 +252,34 @@ bool StyleSet::getImpl(QVariant& value, const QString& key) const
 
 QVariant StyleSet::get(const QString& key) const
 {
-  QVariant value;
-  getImpl(value, key);
-  return value;
+  PropValues values;
+  getImpl(values, key);
+
+  if (values.size() == 1) {
+    auto conv = convertProperty<QString>(values[0]);
+    if (conv) {
+      return QVariant::fromValue(*conv);
+    }
+  }
+  else {
+    // TODO.  We should actually check each propValue what would be the best
+    // thing for it to convert, too.  -> Let's make a
+    // convertProperty<QVariantList>() overload which drives a variant
+    // visitor.
+    QVariantList result;
+    for (const auto& propValue : values) {
+      auto conv = convertProperty<QString>(propValue);
+      if (conv) {
+        result.push_back(conv.get());
+      }
+    }
+
+    return result;
+  }
+
+  return QVariant();
 }
+
 
 QColor StyleSet::color(const QString& key) const
 {
@@ -384,7 +288,7 @@ QColor StyleSet::color(const QString& key) const
 
 QFont StyleSet::font(const QString& key) const
 {
-  return lookupProperty<QFont>(key, FontPropertyConvertTraits());
+  return lookupProperty<QFont>(key);
 }
 
 double StyleSet::number(const QString& key) const

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -304,7 +304,7 @@ public:
    *
    * @par Example for font specs:
    * @code
-   *   italic 12px Calibre
+   *   italic 14.5pt Calibre
    *   oblique smallcaps bold 24px Arial
    * @endcode
    *

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -225,6 +225,8 @@ public:
    * - by RGB string, e.g. @c \#3f4f5f
    * - by ARGB string, e.g. @c \#a0ff0022.
    * - then special @c transparent color
+   * - CSS color expressions like `rgb(120, 64, 230)` or `hsla(340, 20%,
+   *   34%, 0.5)`.
    *
    * Style property names can be any string, but typically end with @c
    * "-color".

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #pragma once
 
+#include "Property.hpp"
 #include "StyleMatchTree.hpp"
 #include "Warnings.hpp"
 
@@ -45,15 +46,6 @@ namespace stylesheets
 
 class StyleEngine;
 class StyleSetAttached;
-
-/*! @cond DOXYGEN_IGNORE */
-namespace detail
-{
-template <typename T>
-struct PropertyConvertTraits;
-}
-
-/*! @endcond */
 
 /*! An attached type used for accessing CSS like style settings
  *
@@ -356,10 +348,10 @@ public Q_SLOTS:
 
 private:
   QObject* grandParent();
-  bool getImpl(QVariant& value, const QString& key) const;
+  bool getImpl(PropValues& value, const QString& key) const;
 
-  template <typename T, typename Traits = detail::PropertyConvertTraits<T>>
-  T lookupProperty(const QString& key, Traits traits = Traits()) const;
+  template <typename T>
+  T lookupProperty(const QString& key) const;
 
 private:
   friend class StyleSetAttached;

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -216,6 +216,27 @@ public:
    */
   Q_INVOKABLE QVariant get(const QString& key) const;
 
+  /*! Returns the style property named @p key
+   *
+   * Looks up the style property named @p key, evaluates expressions and returns
+   * the result.  The output is either a @c string (@c QString), the resulting
+   * type of a CSS value expression (e.g. `rgb()`, `url()`, etc.) or a list of
+   * these types (@c QVariantList).
+   *
+   * @note If there's no such property this method will return an default
+   *       constructed @c QVariant which maps to `undefined` in Javascript/QML.
+   *
+   * @par Example:
+   * @code
+   * Rectangle {
+   *   color: StyleSet.props.values("clip-colors")[clipColorId]
+   * }
+   * @endcode
+   *
+   * @since 1.2
+   */
+  Q_REVISION(2) Q_INVOKABLE QVariant values(const QString& key) const;
+
   /*! Returns the style property @p key as a @c QColor.
    *
    * Looks up the style property named @p key and interprets its value as a

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -226,9 +226,8 @@ public:
 
   /*! Returns the style property @p key as a @c QColor.
    *
-   * Looks up the style property named @p key and interprets its first value as
-   * a color specification.  All common color specs QML supports can be used
-   * here:
+   * Looks up the style property named @p key and interprets its value as a
+   * color specification.  All common color specs QML supports can be used here:
    *
    * - by name, e.g. @c red, @c black, @c yellow
    * - by RGB string, e.g. @c \#3f4f5f
@@ -238,8 +237,9 @@ public:
    * Style property names can be any string, but typically end with @c
    * "-color".
    *
-   * If there's no such property @p key or its first values can not be
-   * converted to a @c QColor prints a warning.
+   * If there's no such property @p key, the property has multiple values, or
+   * the property's value can not be converted to a `QColor` prints a warning
+   * and returns a default `QColor`.
    *
    * @par Example:
    * @code
@@ -252,9 +252,15 @@ public:
 
   /*! Returns the style property @p key as a boolean value
    *
-   * Looks up the style property named @p key and interprets its first value
-   * as a boolean.  If there's no such property @p key or its first value can
-   * not be converted to a boolean value prints a warning.
+   * Looks up the style property named @p key and interprets its value as a
+   * boolean.  If there's no such property @p key, its value can not be
+   * converted to a boolean, or the property has multiple values prints a
+   * warning and returns false.
+   *
+   * Only the following conversions are supported:
+   *
+   * - "true", "yes" -> true
+   * - "false", "no" -> false
    *
    * @par Example:
    * @code
@@ -267,9 +273,10 @@ public:
 
   /*! Returns the style property @p key as a number
    *
-   * Looks up the style property named @p key and interprets its first value
-   * as a number (a double).  If there's no such property @p key or its first
-   * value can not be converted to a double prints a warning.
+   * Looks up the style property named @p key and interprets its value as a
+   * number (a double).  If there's no such property @p key, its value can not
+   * be converted to a double, or the property has multiple values prints a
+   * warning and return 0.0.
    *
    * @par Example:
    * @code
@@ -282,23 +289,24 @@ public:
 
   /*! Returns the style property @p key as a @c QFont
    *
-   * Looks up the style property named @p key and interprets its first value as
-   * a CSS like font specification.  The font string has the format:
+   * Looks up the style property named @p key and interprets its value as a CSS
+   * like font specification.  The font string has the format (with the terms in
+   * `[]` being optional; the order is important though):
    *
    * <pre>
-   * style capMode weight size familyName
+   * [style] [capMode] [weight] [size] familyName
    * </pre>
    *
    * Where the following values are defined:
    *
-   * - __style__: italic, upright, oblique
-   * - __weight__: light, regular, demibold, bold
-   * - __capMode__: mixedcase, alluppercase, alllowercase, smallcaps, capitalize
+   * - __style__: `italic`, `upright`, `oblique`
+   * - __weight__: `light`, `regular`, `demibold`, `bold`
+   * - __capMode__: `mixedcase`, `alluppercase`, `alllowercase`, `smallcaps`, `capitalize`
    *
-   * The __size__ can either be given in pixels or points (e.g. @c 12px or @c 11pt).
-   * The __familyName__ is any valid family name currently installed on the
-   * system, loaded via @c FontLoader or directive or via the @c font-face
-   * declaration from a style sheet.
+   * The __size__ can either be given in pixels or points (e.g. @c 12px or @c
+   * 11pt).  The __familyName__ is any valid family name currently installed on
+   * the system, loaded via a @c FontLoader or via the @c font-face declaration
+   * from a style sheet.
    *
    * @par Example for font specs:
    * @code
@@ -306,8 +314,9 @@ public:
    *   oblique smallcaps bold 24px Arial
    * @endcode
    *
-   * If there's no such property @p key or its first value can not be
-   * converted to a font spec prints a warning.
+   * If there's no such property @p key, its value can not be converted to a
+   * font spec, or the property has multiple values prints a warning and returns
+   * a default constructed QFont.
    *
    * @par Example:
    * @code

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -200,9 +200,8 @@ public:
 
   /*! Returns the style property named @p key
    *
-   * Looks up the style property named @p key and returns it as is.  The
-   * output time is either a @c string (@c QString) or a list of strings (@c
-   * QVariantList).
+   * Looks up the style property named @p key and returns it as is.  The output
+   * is either a @c string (@c QString) or a list of strings (@c QVariantList).
    *
    * @note If there's no such property returns an invalid @c QVariant which
    * maps to @c undefined into Javascript/QML.
@@ -341,6 +340,30 @@ public:
    * @endcode
    */
   Q_INVOKABLE QFont font(const QString& key) const;
+
+  /*! Returns the style property @p key as a string
+   *
+   * Looks up the style property named @p key and interprets its value as a
+   * string.  If there's no such property @p key, first value can not be
+   * converted to a string (esp. a CSS expression like `rgb()` can not be
+   * converted), or the property has multiple values prints a warning and
+   * returns an empty string.
+   *
+   * @par Example:
+   * @code
+   * Text {
+   *   text: StyleSet.props.string("title")
+   * }
+   * @endcode
+   *
+   * @note The main difference to the generic get() function is that it will
+   *       always return a single value only, where get() might return a list of
+   *       strings.  This accessor should be used therefore when a single string
+   *       is expected.
+   *
+   * @since 1.2
+   */
+  Q_REVISION(2) Q_INVOKABLE QString string(const QString& key) const;
 
   /*! @cond DOXYGEN_IGNORE */
   void loadProperties(QObject* pRefObject);

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -261,6 +261,21 @@ public:
    *   color: StyleSet.props.color("background-color")
    * }
    * @endcode
+   *
+   * The following CSS color expressions are supported:
+   *
+   * - `rgb(r, g, b)` where `r` (red), `g` (green), and `b` (blue) can be
+   *   integers from `0` to `255` or percentage values (e.g. `97%`).
+   * - `rgba(r, g, b, a)`, like `rgb()`, `a` (alpha) is a float from `0.0` to
+   *   `1.0`.
+   * - `hsl(h, s, l)` where `h` (hue) is an integer value from `0` to `359` and
+   *   `s` (saturation) and `l` (lightness) are percentage values (e.g. `45%`).
+   * - `hsla(h, s, l, a)` like `hsl()`, `a` (alpha) is a float from `0.0` to
+       `1.0`.
+   * - `hsb(h, s, b)`, like `hsl()`, but instead of lightness takes `b`
+   *   (brightness) as percentage.
+   * - `hsba(h, s, b, a)`, like `hsla()`, but instead of lightness takes `b`
+   *   (brightness) as percentage.
    */
   Q_INVOKABLE QColor color(const QString& key) const;
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -28,6 +28,7 @@ target_compile_options(gtest_internal PUBLIC
   ${cxx11_options} -Wno-global-constructors)
 
 add_executable(StyleSheetParserTest
+  tst_Convert.cpp
   tst_CssParser.cpp
   tst_StyleMatchTree.cpp
 )

--- a/src/test/tst_Convert.cpp
+++ b/src/test/tst_Convert.cpp
@@ -258,3 +258,61 @@ TEST(Convert, colors_hsla_expression_fails)
   EXPECT_FALSE(convertProperty<QColor>(
     Expression{"hsla", std::vector<std::string>{"0.5", "0.75", "1.0", "0.3"}}));
 }
+
+TEST(Convert, colors_hsb_expression)
+{
+  QColor c1;
+  c1.setHsvF(0.25, 0.25, 0.75, 1.0);
+
+  EXPECT_EQ(c1, *convertProperty<QColor>(
+                  Expression{"hsb", std::vector<std::string>{"90", "25%", "75%"}}));
+
+  QColor c2;
+  c2.setHsvF(1.0, 0.0, 1.0, 1.0);
+  EXPECT_EQ(c2, *convertProperty<QColor>(
+                  Expression{"hsb", std::vector<std::string>{"375", "0%", "100%"}}));
+}
+
+TEST(Convert, colors_hsb_expression_fails)
+{
+  // hsb() needs exactly 3 arguments
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsb", std::vector<std::string>{"90", "25%", "75%", "0.1"}}));
+
+  // arguments are degrees, percentage, percantage
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsb", std::vector<std::string>{"90%", "0%", "100%"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsb", std::vector<std::string>{"255", "50", "100"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsb", std::vector<std::string>{"0.5", "0.75", "1.0"}}));
+}
+
+TEST(Convert, colors_hsba_expression)
+{
+  QColor c1;
+  c1.setHsvF(0.25, 0.25, 0.75, 0.6);
+
+  EXPECT_EQ(c1, *convertProperty<QColor>(Expression{
+                  "hsba", std::vector<std::string>{"90", "25%", "75%", "0.6"}}));
+
+  QColor c2;
+  c2.setHsvF(1.0, 0.0, 1.0, 1.0);
+  EXPECT_EQ(c2, *convertProperty<QColor>(Expression{
+                  "hsba", std::vector<std::string>{"375", "0%", "100%", "1.0"}}));
+}
+
+TEST(Convert, colors_hsba_expression_fails)
+{
+  // hsba() needs exactly 4 arguments
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsba", std::vector<std::string>{"90", "25%", "75%"}}));
+
+  // arguments are degrees, percentage, percantage
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsba", std::vector<std::string>{"90%", "0%", "100%", "20%"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsba", std::vector<std::string>{"255", "50", "100", "75"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsba", std::vector<std::string>{"0.5", "0.75", "1.0", "0.3"}}));
+}

--- a/src/test/tst_Convert.cpp
+++ b/src/test/tst_Convert.cpp
@@ -123,3 +123,120 @@ TEST(Convert, colors_failing)
   EXPECT_EQ(
     QColor(), *convertProperty<QColor>(PropertyValue(std::string("hello world"))));
 }
+
+TEST(Convert, colors_rgb_expression)
+{
+  EXPECT_EQ(
+    QColor(254, 112, 1, 255), *convertProperty<QColor>(Expression{
+                                "rgb", std::vector<std::string>{"254", "112", "1"}}));
+
+  EXPECT_EQ(QColor(254, 128, 255, 255),
+            *convertProperty<QColor>(
+              Expression{"rgb", std::vector<std::string>{"254", "50%", "100%"}}));
+}
+
+TEST(Convert, colors_rgb_expression_fails)
+{
+  // rgb() requires exactly 3 parameters
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"rgb", std::vector<std::string>{"254", "112", "1", "0.5"}}));
+
+  EXPECT_FALSE(
+    convertProperty<QColor>(Expression{"rgb", std::vector<std::string>{"254"}}));
+
+  // rgb() requires integers or percentage, not floats for the color channel
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"rgb", std::vector<std::string>{"0.1", "1.0", "0.3"}}));
+}
+
+TEST(Convert, colors_rgba_expression)
+{
+  EXPECT_EQ(QColor(254, 112, 1, 128),
+            *convertProperty<QColor>(
+              Expression{"rgba", std::vector<std::string>{"254", "112", "1", "0.5"}}));
+
+  EXPECT_EQ(QColor(64, 128, 255, 0),
+            *convertProperty<QColor>(
+              Expression{"rgba", std::vector<std::string>{"25%", "50%", "100%", "0.0"}}));
+}
+
+TEST(Convert, colors_rgba_expression_fails)
+{
+  // rgba() requires exactly 4 parameters
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"rgba", std::vector<std::string>{"254", "112", "1"}}));
+
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"rgba", std::vector<std::string>{"254", "112", "23", "0.5", "712"}}));
+
+  // rgba() requires integers or percentage for the color channels, but a float
+  // for the alpha channel
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"rgba", std::vector<std::string>{"0.1", "1.0", "0.3", "0.4"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"rgba", std::vector<std::string>{"100%", "100%", "100%", "100%"}}));
+
+  // BUT: the following expression works, because "12" is a rather large float
+  // which is clamped to 1.0f (=255).
+  EXPECT_EQ(QColor(128, 64, 0, 255),
+            *convertProperty<QColor>(
+              Expression{"rgba", std::vector<std::string>{"128", "64", "0", "12"}}));
+}
+
+TEST(Convert, colors_hsl_expression)
+{
+  QColor c1;
+  c1.setHslF(0.25, 0.25, 0.75, 1.0);
+
+  EXPECT_EQ(c1, *convertProperty<QColor>(
+                  Expression{"hsl", std::vector<std::string>{"90", "25%", "75%"}}));
+
+  QColor c2;
+  c2.setHslF(1.0, 0.0, 1.0, 1.0);
+  EXPECT_EQ(c2, *convertProperty<QColor>(
+                  Expression{"hsl", std::vector<std::string>{"375", "0%", "100%"}}));
+}
+
+TEST(Convert, colors_hsl_expression_fails)
+{
+  // hsl() needs exactly 3 arguments
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsl", std::vector<std::string>{"90", "25%", "75%", "0.1"}}));
+
+  // arguments are degrees, percentage, percantage
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsl", std::vector<std::string>{"90%", "0%", "100%"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsl", std::vector<std::string>{"255", "50", "100"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsl", std::vector<std::string>{"0.5", "0.75", "1.0"}}));
+}
+
+TEST(Convert, colors_hsla_expression)
+{
+  QColor c1;
+  c1.setHslF(0.25, 0.25, 0.75, 0.6);
+
+  EXPECT_EQ(c1, *convertProperty<QColor>(Expression{
+                  "hsla", std::vector<std::string>{"90", "25%", "75%", "0.6"}}));
+
+  QColor c2;
+  c2.setHslF(1.0, 0.0, 1.0, 1.0);
+  EXPECT_EQ(c2, *convertProperty<QColor>(Expression{
+                  "hsla", std::vector<std::string>{"375", "0%", "100%", "1.0"}}));
+}
+
+TEST(Convert, colors_hsla_expression_fails)
+{
+  // hsla() needs exactly 4 arguments
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsla", std::vector<std::string>{"90", "25%", "75%"}}));
+
+  // arguments are degrees, percentage, percantage
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsla", std::vector<std::string>{"90%", "0%", "100%", "20%"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsla", std::vector<std::string>{"255", "50", "100", "75"}}));
+  EXPECT_FALSE(convertProperty<QColor>(
+    Expression{"hsla", std::vector<std::string>{"0.5", "0.75", "1.0", "0.3"}}));
+}

--- a/src/test/tst_Convert.cpp
+++ b/src/test/tst_Convert.cpp
@@ -99,6 +99,24 @@ TEST(Convert, fonts_with_partial_specification)
   EXPECT_EQ(QFont::MixedCase, f->capitalization());
 }
 
+TEST(Convert, fonts_with_float_size)
+{
+  auto f = convertProperty<QFont>(PropertyValue(std::string("12.7pt Arial")));
+
+  EXPECT_TRUE(f);
+  EXPECT_EQ(QLatin1String("Arial"), f->family());
+  EXPECT_EQ(12.7, f->pointSizeF());
+}
+
+TEST(Convert, fonts_with_pixelsize)
+{
+  auto f = convertProperty<QFont>(PropertyValue(std::string("18px Arial")));
+
+  EXPECT_TRUE(f);
+  EXPECT_EQ(QLatin1String("Arial"), f->family());
+  EXPECT_EQ(18, f->pixelSize());
+}
+
 //----------------------------------------------------------------------------------------
 
 TEST(Convert, colors_rgb_hash)

--- a/src/test/tst_Convert.cpp
+++ b/src/test/tst_Convert.cpp
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2015 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "Convert.hpp"
+
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtCore/QString>
+#include <QtGui/QColor>
+#include <QtGui/QFont>
+#include <gtest/gtest.h>
+RESTORE_WARNINGS
+
+//========================================================================================
+
+using namespace aqt::stylesheets;
+
+TEST(Convert, qString)
+{
+  EXPECT_EQ(QLatin1String("hello world!"),
+            *convertProperty<QString>(PropertyValue(std::string("hello world!"))));
+  EXPECT_EQ(QString(), *convertProperty<QString>(PropertyValue(std::string())));
+  EXPECT_EQ(
+    QLatin1String("3.14"), *convertProperty<QString>(PropertyValue(std::string("3.14"))));
+
+  EXPECT_FALSE(convertProperty<QString>(
+    PropertyValue(Expression({"ix", std::vector<std::string>{"250"}}))));
+}
+
+TEST(Convert, qDouble)
+{
+  EXPECT_EQ(3.14, *convertProperty<double>(PropertyValue(std::string("3.14"))));
+  EXPECT_EQ(0.0, *convertProperty<double>(PropertyValue(std::string("0"))));
+  EXPECT_FALSE(convertProperty<double>(PropertyValue(std::string("hello world"))));
+}
+
+TEST(Convert, boolean)
+{
+  EXPECT_TRUE(convertProperty<bool>(PropertyValue(std::string("true"))).get());
+  EXPECT_TRUE(convertProperty<bool>(PropertyValue(std::string("True"))).get());
+  EXPECT_TRUE(convertProperty<bool>(PropertyValue(std::string("YES"))).get());
+  EXPECT_TRUE(convertProperty<bool>(PropertyValue(std::string("yEs"))).get());
+  EXPECT_FALSE(convertProperty<bool>(PropertyValue(std::string("no"))).get());
+  EXPECT_FALSE(convertProperty<bool>(PropertyValue(std::string("false"))).get());
+  EXPECT_FALSE(convertProperty<bool>(PropertyValue(std::string("1"))));
+  EXPECT_FALSE(convertProperty<bool>(PropertyValue(std::string())));
+
+  EXPECT_FALSE(convertProperty<bool>(
+    PropertyValue(Expression({"ix", std::vector<std::string>{"250"}}))));
+}
+
+//----------------------------------------------------------------------------------------
+
+TEST(Convert, fonts)
+{
+  auto f = convertProperty<QFont>(
+    PropertyValue(std::string("italic mixedcase light 12pt Times New Roman")));
+
+  EXPECT_TRUE(f);
+  EXPECT_EQ(QLatin1String("Times New Roman"), f->family());
+  EXPECT_EQ(12, f->pointSize());
+  EXPECT_TRUE(f->italic());
+  EXPECT_FALSE(f->bold());
+  EXPECT_EQ(QFont::Light, f->weight());
+  EXPECT_EQ(QFont::MixedCase, f->capitalization());
+}
+
+TEST(Convert, fonts_with_partial_specification)
+{
+  auto f = convertProperty<QFont>(PropertyValue(std::string("12pt Arial")));
+
+  EXPECT_TRUE(f);
+  EXPECT_EQ(QLatin1String("Arial"), f->family());
+  EXPECT_EQ(12, f->pointSize());
+  EXPECT_FALSE(f->italic());
+  EXPECT_FALSE(f->bold());
+  EXPECT_EQ(QFont::StyleNormal, f->style());
+  EXPECT_EQ(QFont::Normal, f->weight());
+  EXPECT_EQ(QFont::MixedCase, f->capitalization());
+}
+
+//----------------------------------------------------------------------------------------
+
+TEST(Convert, colors_rgb_hash)
+{
+  EXPECT_EQ(QColor(0xde, 0xad, 0x01, 0xff),
+            *convertProperty<QColor>(PropertyValue(std::string("#dead01"))));
+  EXPECT_EQ(QColor(0x00, 0x00, 0x00, 0xff),
+            *convertProperty<QColor>(PropertyValue(std::string("#000000"))));
+}
+
+TEST(Convert, colors_argb_hash)
+{
+  EXPECT_EQ(QColor(0xde, 0xad, 0x01, 0xe3),
+            *convertProperty<QColor>(PropertyValue(std::string("#e3dead01"))));
+  EXPECT_EQ(QColor(0xad, 0xfa, 0xce, 0xde),
+            *convertProperty<QColor>(PropertyValue(std::string("#deadface"))));
+}
+
+TEST(Convert, colors_failing)
+{
+  // Questionable API
+  EXPECT_EQ(
+    QColor(), *convertProperty<QColor>(PropertyValue(std::string("hello world"))));
+}

--- a/src/test/tst_CssParser.cpp
+++ b/src/test/tst_CssParser.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2014-15 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,8 @@ THE SOFTWARE.
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
+#include <boost/variant/get.hpp>
+#include <boost/variant/variant.hpp>
 #include <gtest/gtest.h>
 RESTORE_WARNINGS
 
@@ -54,8 +56,26 @@ std::string selectorName(const StyleSheet& ss,
 
 std::string getFirstValue(const PropValues& val, const std::string& def = "")
 {
-  return !val.empty() ? val[0] : def;
+  if (!val.empty()) {
+    if (const std::string* str = boost::get<std::string>(&val[0])) {
+      return *str;
+    }
+  }
+
+  return def;
 }
+
+Expression getExpr(const PropValues& val, size_t idx, const Expression& def = {})
+{
+  if (!val.empty()) {
+    if (const Expression* expr = boost::get<Expression>(&val[idx])) {
+      return *expr;
+    }
+  }
+
+  return def;
+}
+
 
 size_t getNumberOfValues(const PropValues& val)
 {
@@ -314,6 +334,44 @@ TEST(CssParserTest, ParserFromString_fontFaceDeclarations)
   EXPECT_EQ(ss.fontfaces.size(), 1);
 
   EXPECT_EQ(ss.fontfaces[0].url, "../../Assets/times.ttf");
+}
+
+//----------------------------------------------------------------------------------------
+
+TEST(CssParserTest, ParserFromString_Expressions)
+{
+  const std::string src = "foo { bar: url('hello world'); }\n";
+
+  StyleSheet ss = parseStdString(src);
+  EXPECT_EQ(1, ss.propsets.size());
+  EXPECT_EQ(1, ss.propsets[0].properties.size());
+  EXPECT_EQ(1, getNumberOfValues(ss.propsets[0].properties[0].values));
+
+  EXPECT_EQ(std::string("url"), getExpr(ss.propsets[0].properties[0].values, 0).name);
+  EXPECT_EQ((std::vector<std::string>{"hello world"}),
+            getExpr(ss.propsets[0].properties[0].values, 0).args);
+}
+
+TEST(CssParserTest, ParserFromString_ExpressionsInLists)
+{
+  const std::string src =
+    "foo { bar: rgba(123, 45, 92, 0.1), "
+    "           foo(), "
+    "           hsla(320, 100%, 20%, 0.3); }\n";
+
+  StyleSheet ss = parseStdString(src);
+  EXPECT_EQ(1, ss.propsets.size());
+  EXPECT_EQ(1, ss.propsets[0].properties.size());
+
+  EXPECT_EQ(std::string("rgba"), getExpr(ss.propsets[0].properties[0].values, 0).name);
+  EXPECT_EQ((std::vector<std::string>{"123", "45", "92", "0.1"}),
+            getExpr(ss.propsets[0].properties[0].values, 0).args);
+  EXPECT_EQ(std::string("foo"), getExpr(ss.propsets[0].properties[0].values, 1).name);
+  EXPECT_TRUE(getExpr(ss.propsets[0].properties[0].values, 1).args.empty());
+
+  EXPECT_EQ(std::string("hsla"), getExpr(ss.propsets[0].properties[0].values, 2).name);
+  EXPECT_EQ((std::vector<std::string>{"320", "100%", "20%", "0.3"}),
+            getExpr(ss.propsets[0].properties[0].values, 2).args);
 }
 
 /* Missing tests:

--- a/src/test/tst_StyleMatchTree.cpp
+++ b/src/test/tst_StyleMatchTree.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014 Ableton AG, Berlin
+Copyright (c) 2014-15 Ableton AG, Berlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,31 +22,31 @@ THE SOFTWARE.
 
 #include "StyleMatchTree.hpp"
 
+#include "Convert.hpp"
 #include "CssParser.hpp"
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
 #include <QtCore/QString>
 #include <gtest/gtest.h>
+#include <boost/variant/get.hpp>
 RESTORE_WARNINGS
 
 #include <iostream>
 
 //========================================================================================
 
-// This must live outside of any namespace, otherwise C++ won't match QString
-static void PrintTo(const QString& str, ::std::ostream* os)
-{
-  *os << "\"" << str.toStdString() << "\"";
-}
-
 using namespace aqt::stylesheets;
 
 namespace
 {
-QString propertyAsString(PropertyMap pm, const char* pPropertyName)
+std::string propertyAsString(PropertyMap pm, const char* pPropertyName)
 {
-  return pm[QString(pPropertyName)].value<QString>();
+  if (const std::string* str = boost::get<std::string>(&pm[QString(pPropertyName)][0])) {
+    return *str;
+  }
+  return std::string();
+}
 }
 } // anon namespace
 

--- a/src/test/tst_StyleMatchTree.cpp
+++ b/src/test/tst_StyleMatchTree.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 SUPPRESS_WARNINGS
 #include <QtCore/QString>
+#include <QtGui/QColor>
 #include <gtest/gtest.h>
 #include <boost/variant/get.hpp>
 RESTORE_WARNINGS
@@ -47,6 +48,14 @@ std::string propertyAsString(PropertyMap pm, const char* pPropertyName)
   }
   return std::string();
 }
+
+QColor propertyAsColor(PropertyMap pm, const char* pPropertyName)
+{
+  auto result = convertProperty<QColor>(pm[QString(pPropertyName)][0]);
+  if (result) {
+    return *result;
+  }
+  return QColor();
 }
 } // anon namespace
 
@@ -509,4 +518,112 @@ TEST(StyleMatchTreeTest, multipleClassNames_even_without_whitespace)
   EXPECT_EQ("1", propertyAsString(pm, "propA"));
   EXPECT_EQ("2", propertyAsString(pm, "propB"));
   EXPECT_EQ("3", propertyAsString(pm, "propC"));
+}
+
+//----------------------------------------------------------------------------------------
+
+TEST(StyleMatchTreeTest, rgbColors_with_percentage_value)
+{
+  const std::string src =
+    ".foo { color: rgb(0%, 25%, 100%); }\n"
+    ".bar { color: rgb(10%, 75%, 95%); }\n";
+
+  StyleSheet ss = parseStdString(src);
+
+  StyleMatchTree mt = createMatchTree(parseStdString(src));
+  {
+    UiItemPath p = {PathElement("Bar", {"foo"})};
+    PropertyMap pm = matchPath(mt, p);
+
+    EXPECT_EQ(1, pm.size());
+    EXPECT_EQ(0x00, propertyAsColor(pm, "color").red());
+    EXPECT_EQ(0x40, propertyAsColor(pm, "color").green());
+    EXPECT_EQ(0xff, propertyAsColor(pm, "color").blue());
+    EXPECT_EQ(0xff, propertyAsColor(pm, "color").alpha());
+  }
+
+  {
+    UiItemPath p = {PathElement("Bar", {"bar"})};
+    PropertyMap pm = matchPath(mt, p);
+
+    EXPECT_EQ(1, pm.size());
+    EXPECT_EQ(0x1a, propertyAsColor(pm, "color").red());
+    EXPECT_EQ(0xbf, propertyAsColor(pm, "color").green());
+    EXPECT_EQ(0xf2, propertyAsColor(pm, "color").blue());
+    EXPECT_EQ(0xff, propertyAsColor(pm, "color").alpha());
+  }
+}
+
+TEST(StyleMatchTreeTest, rgbColors)
+{
+  const std::string src = ".foo { color: rgb(0, 16, 32); }\n";
+
+  StyleSheet ss = parseStdString(src);
+  EXPECT_EQ(ss.propsets.size(), 1);
+
+  StyleMatchTree mt = createMatchTree(parseStdString(src));
+  UiItemPath p = {PathElement("Bar", {"foo"})};
+  PropertyMap pm = matchPath(mt, p);
+
+  EXPECT_EQ(1, pm.size());
+  EXPECT_EQ(0x00, propertyAsColor(pm, "color").red());
+  EXPECT_EQ(0x10, propertyAsColor(pm, "color").green());
+  EXPECT_EQ(0x20, propertyAsColor(pm, "color").blue());
+  EXPECT_EQ(0xff, propertyAsColor(pm, "color").alpha());
+}
+
+
+TEST(StyleMatchTreeTest, rgbaColors)
+{
+  const std::string src = ".foo { color: rgba(0, 16, 32, 0.5); }\n";
+
+  StyleSheet ss = parseStdString(src);
+  EXPECT_EQ(ss.propsets.size(), 1);
+
+  StyleMatchTree mt = createMatchTree(parseStdString(src));
+  UiItemPath p = {PathElement("Bar", {"foo"})};
+  PropertyMap pm = matchPath(mt, p);
+
+  EXPECT_EQ(1, pm.size());
+  EXPECT_EQ(0x00, propertyAsColor(pm, "color").red());
+  EXPECT_EQ(0x10, propertyAsColor(pm, "color").green());
+  EXPECT_EQ(0x20, propertyAsColor(pm, "color").blue());
+  EXPECT_EQ(0x80, propertyAsColor(pm, "color").alpha());
+}
+
+
+TEST(StyleMatchTreeTest, hslColors)
+{
+  const std::string src = ".foo { color: hsl(120, 100%, 50%); }\n";
+
+  StyleSheet ss = parseStdString(src);
+  EXPECT_EQ(ss.propsets.size(), 1);
+
+  StyleMatchTree mt = createMatchTree(parseStdString(src));
+  UiItemPath p = {PathElement("Bar", {"foo"})};
+  PropertyMap pm = matchPath(mt, p);
+
+  EXPECT_EQ(1, pm.size());
+  EXPECT_EQ(120, propertyAsColor(pm, "color").hslHue());
+  EXPECT_NEAR(1.0f, propertyAsColor(pm, "color").hslSaturationF(), 0.00001f);
+  EXPECT_NEAR(0.5f, propertyAsColor(pm, "color").lightnessF(), 0.00001f);
+}
+
+
+TEST(StyleMatchTreeTest, hslaColors)
+{
+  const std::string src = ".foo { color: hsla(359, 97%, 13%, 0.23); }\n";
+
+  StyleSheet ss = parseStdString(src);
+  EXPECT_EQ(ss.propsets.size(), 1);
+
+  StyleMatchTree mt = createMatchTree(parseStdString(src));
+  UiItemPath p = {PathElement("Bar", {"foo"})};
+  PropertyMap pm = matchPath(mt, p);
+
+  EXPECT_EQ(1, pm.size());
+  EXPECT_EQ(359, propertyAsColor(pm, "color").hslHue());
+  EXPECT_NEAR(0.97f, propertyAsColor(pm, "color").hslSaturationF(), 0.00001f);
+  EXPECT_NEAR(0.13f, propertyAsColor(pm, "color").lightnessF(), 0.00001f);
+  EXPECT_NEAR(0.23f, propertyAsColor(pm, "color").alphaF(), 0.00001f);
 }

--- a/tests/tst_Properties.qml
+++ b/tests/tst_Properties.qml
@@ -61,6 +61,62 @@ Item {
     //--------------------------------------------------------------------------
 
     Component {
+        id: stringLookupScene
+
+        Item {
+            property alias gaz: rect1.gaz
+
+            Rectangle {
+                id: rect1
+                StyleSet.name: "root"
+                anchors.fill: parent
+
+                property var gaz: StyleSet.props.string("gaz")
+            }
+        }
+    }
+
+    Component {
+        id: badStringLookupScene
+
+        Item {
+            property alias foo: rect1b.foo
+
+            Rectangle {
+                id: rect1b
+                StyleSet.name: "root"
+                anchors.fill: parent
+
+                property var foo: StyleSet.props.string("foo")
+            }
+        }
+    }
+
+    TestCase {
+        name: "lookup a string"
+        when: windowShown
+
+        function test_lookupASingleString() {
+            TestUtils.withComponent(stringLookupScene, scene, {}, function(comp) {
+                // single string
+                compare(comp.gaz, "hello world!");
+            });
+        }
+
+        function test_lookupASingleString_fails() {
+            msgTracker.expectMessage(AqtTests.TestUtils.Warning,
+                                     /^.*Property.*is not convertible.*QString.*/);
+            TestUtils.withComponent(badStringLookupScene, scene, {}, function(comp) {
+                // multiple string fails, props.string() returns an empty string.
+                compare(comp.foo, "");
+            });
+        }
+    }
+
+
+    //--------------------------------------------------------------------------
+
+    Component {
         id: multipleColorsScene
 
         Item {

--- a/tests/tst_Properties.qml
+++ b/tests/tst_Properties.qml
@@ -1,0 +1,123 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+import QtTest 1.0
+import QtQuick.Layouts 1.1
+
+import Aqt.StyleSheets 1.2
+import Aqt.StyleSheets.Tests 1.0 as AqtTests
+
+import "testUtils.js" as TestUtils
+
+Item {
+    id: scene
+
+    /*! ensure minimum width to be larger than the minimum allowed width on
+     * Windows */
+    implicitWidth: 124
+    /*! there are no constraints on the height, but it is convenient to have a
+     *  default size */
+    implicitHeight: 116
+
+
+    AqtTests.TestUtils {
+        id: msgTracker
+    }
+
+    StyleEngine {
+        id: styleEngine
+        styleSheetSource: "tst_Props.css"
+    }
+
+    Component {
+        id: singleColorScene
+
+        Item {
+            property alias foo: rect.foo
+
+            Rectangle {
+                id: rect
+                StyleSet.name: "root"
+                anchors.fill: parent
+
+                property var foo: StyleSet.props.color("bar")
+            }
+        }
+    }
+
+    TestCase {
+        name: "lookup and convert a single color"
+        when: windowShown
+
+        function test_lookupAndConvertASingleColor() {
+            TestUtils.withComponent(singleColorScene, scene, {}, function(comp) {
+                verify(typeof(comp.foo) != "string");
+                verify(Qt.colorEqual(comp.foo, "#123456"));
+            });
+        }
+    }
+
+
+    //--------------------------------------------------------------------------
+
+    Component {
+        id: multipleColorsScene
+
+        Item {
+            property alias foo: rect2.foo
+            property alias foo1: rect2.foo1
+            property alias exprs: rect2.exprs
+
+            Rectangle {
+                id: rect2
+                StyleSet.name: "root"
+                anchors.fill: parent
+
+                property var foo: StyleSet.props.get("foo")
+                property var foo1: StyleSet.props.values("foo")
+                property var exprs: StyleSet.props.values("exprs")
+            }
+        }
+    }
+
+    TestCase {
+        name: "lookup lists of colors."
+        when: windowShown
+
+        // The get() function on StyleSet returns the lookedup value as is (i.e. a list of strings)
+        function test_lookupStringLists() {
+            TestUtils.withComponent(multipleColorsScene, scene, {}, function(comp) {
+                compare(comp.foo.length, 3);
+                verify(Qt.colorEqual(comp.foo[0], "#ff0000"));
+                verify(Qt.colorEqual(comp.foo[1], "#00aa00"));
+                verify(Qt.colorEqual(comp.foo[2], "#000033"));
+                compare(typeof(comp.foo[0]), "string");
+                compare(typeof(comp.foo[1]), "string");
+                compare(typeof(comp.foo[2]), "string");
+
+                compare(comp.foo1.length, 3);
+                verify(Qt.colorEqual(comp.foo1[0], "#ff0000"));
+                verify(Qt.colorEqual(comp.foo1[1], "#00aa00"));
+                verify(Qt.colorEqual(comp.foo1[2], "#000033"));
+
+                compare(typeof(comp.foo1[0]), "string");
+                compare(typeof(comp.foo1[1]), "string");
+                compare(typeof(comp.foo1[2]), "string");
+            });
+        }
+
+        function test_lookupListsOfColors() {
+            TestUtils.withComponent(multipleColorsScene, scene, {}, function(comp) {
+                compare(comp.foo1.length, 3);
+
+                verify(Qt.colorEqual(comp.exprs[0], "#ff0000"));
+                verify(Qt.colorEqual(comp.exprs[1], "#008000"));
+                verify(Qt.colorEqual(comp.exprs[2], "#80000040"));
+
+                verify(typeof(comp.exprs[0]) != "string");
+                verify(typeof(comp.exprs[1]) != "string");
+                verify(typeof(comp.exprs[2]) != "string");
+            });
+        }
+    }
+}

--- a/tests/tst_Props.css
+++ b/tests/tst_Props.css
@@ -1,0 +1,14 @@
+/* Copyright (c) 2015 Ableton AG, Berlin */
+
+.root {
+  foo: "#ff0000", "#00AA00", "#000033";
+  bar: "#123456";
+  gaz: "hello world!";
+
+  exprs: rgb(255, 00, 00), rgb(0, 50%, 0), rgba(0, 0, 25%, 0.5);
+}
+
+/* keep this here to make Foo/Bar.qml happy */
+Bar {
+  text: "B";
+}


### PR DESCRIPTION
Add support for color expressions in CSS (like `rgba(100, 120, 250, 0.1)`). 

This implementation is very different from my first approach, but simplifies adding further CSS expression.

@sbs-ableton @rof-ableton