### PR TITLE
Search path for urls

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(StyleSheetParser
   Property.hpp
   StyleMatchTree.cpp
   StyleMatchTree.hpp
+  UrlUtils.cpp
+  UrlUtils.hpp
   Warnings.hpp
 )
 target_include_directories(StyleSheetParser PUBLIC

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "CssParser.hpp"
 #include "Log.hpp"
 #include "StyleMatchTree.hpp"
+#include "UrlUtils.hpp"
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
@@ -323,6 +324,11 @@ StyleEngineHost* StyleEngineHost::globalStyleEngineHost()
 StyleEngine* StyleEngineHost::globalStyleEngine()
 {
   return globalStyleEngineImpl();
+}
+
+QUrl StyleEngine::resolveResourceUrl(const QUrl& baseUrl, const QUrl& url) const
+{
+  return searchForResourceSearchPath(baseUrl, url, qmlEngine(this)->importPathList());
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -30,6 +30,9 @@ THE SOFTWARE.
 
 SUPPRESS_WARNINGS
 #include <QtCore/QPointer>
+#include <QtCore/QFile>
+#include <QtCore/QDir>
+#include <QtCore/QUrl>
 #include <QtGui/QFontDatabase>
 #include <QtQml/QQmlEngine>
 #include <QtQml/QQmlFile>
@@ -214,30 +217,35 @@ void StyleEngine::onFileChanged(const QString&)
 void StyleEngine::resolveFontFaceDecl(const StyleSheet& styleSheet)
 {
   for (auto ffd : styleSheet.fontfaces) {
-    QUrl fontFaceUrl =
-      mStyleSheetSourceUrl.url().resolved(QUrl(QString::fromStdString(ffd.url)));
-
+    QUrl fontFaceUrl = resolveResourceUrl(
+      mStyleSheetSourceUrl.url(), QUrl(QString::fromStdString(ffd.url)));
     QString fontFaceFile = QQmlFile::urlToLocalFileOrQrc(fontFaceUrl);
 
-    styleSheetsLogInfo() << "Load font face " << ffd.url << " from "
-                         << fontFaceFile.toStdString();
+    if (!fontFaceFile.isEmpty()) {
+      styleSheetsLogInfo() << "Load font face " << ffd.url << " from "
+                           << fontFaceFile.toStdString();
+      std::map<QString, int>::iterator fontCacheIt = mFontIdCache.find(fontFaceFile);
+      if (fontCacheIt == mFontIdCache.end()) {
+        int fontId = QFontDatabase::addApplicationFont(fontFaceFile);
+        styleSheetsLogDebug() << " [" << fontId << "]";
 
-    std::map<QString, int>::iterator fontCacheIt = mFontIdCache.find(fontFaceFile);
-    if (fontCacheIt == mFontIdCache.end()) {
-      int fontId = QFontDatabase::addApplicationFont(fontFaceFile);
-      styleSheetsLogDebug() << " [" << fontId << "]";
-
-      if (fontId != -1) {
-        QString fontFamily = QFontDatabase::applicationFontFamilies(fontId).at(0);
-        styleSheetsLogDebug() << " -> family: " << fontFamily.toStdString();
-        mFontIdCache[fontFaceFile] = fontId;
+        if (fontId != -1) {
+          QString fontFamily = QFontDatabase::applicationFontFamilies(fontId).at(0);
+          styleSheetsLogDebug() << " -> family: " << fontFamily.toStdString();
+          mFontIdCache[fontFaceFile] = fontId;
+        } else {
+          Q_EMIT exception(
+            QString::fromLatin1("fontWasNotLoaded"),
+            QString::fromLatin1("Could not find font in font registry after loading."));
+        }
       } else {
-        Q_EMIT exception(
-          QString::fromLatin1("fontWasNotLoaded"),
-          QString::fromLatin1("Could not find font in font registry after loading."));
+        styleSheetsLogDebug() << " [" << fontCacheIt->second << "]";
       }
     } else {
-      styleSheetsLogDebug() << " [" << fontCacheIt->second << "]";
+      styleSheetsLogWarning() << "Could not find font file "
+                              << fontFaceUrl.toString().toStdString();
+      Q_EMIT exception(QString::fromLatin1("fontWasNotLoaded"),
+                       QString::fromLatin1("Font url could not be resolved."));
     }
   }
 }

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -38,7 +38,6 @@ RESTORE_WARNINGS
 
 #include <memory>
 
-
 namespace aqt
 {
 namespace stylesheets
@@ -241,6 +240,13 @@ public:
 
   /*! @private */
   std::string describeMatchedPath(const UiItemPath& path);
+
+  /*! Resolve @p url against @p baseUrl or search for it in a search path.
+   *
+   * See aqt::stylesheets::searchForResourceSearchPath() for details.  This
+   * method takes QQmlEngine::importPathList() as searchPath for url resolution.
+   */
+  QUrl resolveResourceUrl(const QUrl& baseUrl, const QUrl& url) const;
 
 Q_SIGNALS:
   /*! Fires when the style sheet is replaced or changed on the disk */

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -320,7 +320,7 @@ QUrl StyleSet::url(const QString& key) const
   if (mpEngine) {
     auto baseUrl = prop.mSourceLoc.mSourceLayer == 0 ? mpEngine->defaultStyleSheetSource()
                                                      : mpEngine->styleSheetSource();
-    return baseUrl.resolved(url);
+    return mpEngine->resolveResourceUrl(baseUrl, url);
   }
 
   return url;

--- a/src/UrlUtils.cpp
+++ b/src/UrlUtils.cpp
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2015 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "UrlUtils.hpp"
+
+#include "Log.hpp"
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtCore/QDir>
+#include <QtCore/QFile>
+#include <QtCore/QString>
+#include <QtCore/QRegularExpression>
+RESTORE_WARNINGS
+
+#include <vector>
+
+namespace aqt
+{
+namespace stylesheets
+{
+
+QUrl searchForResourceSearchPath(const QUrl& baseUrl,
+                                 const QUrl& url,
+                                 const QStringList& searchPath)
+{
+  if (url.isRelative()) {
+    if (!baseUrl.isLocalFile()) {
+      return baseUrl.resolved(url);
+    }
+
+    auto path = url.path();
+    if (!path.startsWith("/")) {
+      auto resolvedUrl = baseUrl.resolved(url);
+      if (QFile::exists(resolvedUrl.toLocalFile())) {
+        return resolvedUrl;
+      }
+    } else if (!path.contains("/../")) {
+      auto pathRelPart = path.split(QRegularExpression("^/+"))[1];
+      for (const auto str : searchPath) {
+        auto dir = QDir(str);
+        auto absPath = QDir::cleanPath(dir.absoluteFilePath(pathRelPart));
+
+        if (QFile::exists(absPath)) {
+          return QUrl::fromLocalFile(absPath);
+        }
+      }
+
+      return QUrl();
+    } else {
+      return QUrl();
+    }
+  }
+
+  return url;
+}
+
+} // namespace stylesheets
+} // namespace aqt

--- a/src/UrlUtils.hpp
+++ b/src/UrlUtils.hpp
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2015 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtCore/QStringList>
+#include <QtCore/QUrl>
+RESTORE_WARNINGS
+
+namespace aqt
+{
+namespace stylesheets
+{
+/*! Resolve @p url against @p baseUrl or search for it in @p searchPath.
+ *
+ * If @p url is an absolute url @p url is returned as-is.
+ *
+ * If @p baseUrl is not a local file url resolve @p url relative to it.  In this
+ * case @p searchPath is ignored.
+ *
+ * If @p baseUrl is a local file url @p url is resolved depending on @p urls
+ * form.
+ * If @p url starts with a "/" (i.e. is an absolute "relative" path) the path is
+ * tested as relative path to the local file directories in @p searchPath in the
+ * order given.  The first path existing as file on the local file system is
+ * returned as local file url.
+ *
+ * @pre Example
+ * @code
+ * searchPath: ["foo", "bar"] & url: "x/y/z"
+ * tested paths:
+ *   foo/x/y/z
+ *   bar/x/y/z
+ * @endcode
+ *
+ * If no path tested matches the function returns an invalid url.
+ *
+ * @p{url}s starting with "/" must not contain ".." (and invalid url will be
+ * returned otherwise).
+ *
+ * If @p url starts with any other character than "/" (e.g. a letter or ".") the
+ * path is resolved relatived to @p baseUrl *and* tested whether the file exists
+ * on the local file system.  Otherwise an invalid url is returned.
+ */
+QUrl searchForResourceSearchPath(const QUrl& baseUrl,
+                                 const QUrl& url,
+                                 const QStringList& searchPath);
+
+} // namespace stylesheets
+} // namespace aqt

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(StyleSheetParserTest
   tst_Convert.cpp
   tst_CssParser.cpp
   tst_StyleMatchTree.cpp
+  tst_UrlUtils.cpp
 )
 
 target_link_libraries(StyleSheetParserTest

--- a/src/test/tst_UrlUtils.cpp
+++ b/src/test/tst_UrlUtils.cpp
@@ -1,0 +1,239 @@
+/*
+Copyright (c) 2015 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "UrlUtils.hpp"
+#include "Log.hpp"
+
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QTemporaryDir>
+#include <QtCore/QFile>
+#include <QtCore/QUrl>
+#include <gtest/gtest.h>
+RESTORE_WARNINGS
+
+
+using namespace aqt::stylesheets;
+
+
+namespace
+{
+void createFile(QString path)
+{
+  QFile f(path);
+  ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+  f.close();
+}
+
+template <typename TestFn>
+void testWithSandbox(TestFn&& testFn)
+{
+  QTemporaryDir sandbox;
+  if (sandbox.isValid()) {
+    testFn(sandbox);
+  } else {
+    styleSheetsLogError() << "Could not create a temporary folder for test";
+  }
+}
+} // anon namespace
+
+TEST(UrlUtils, resolveResourceUrl_local_to_http)
+{
+  EXPECT_EQ(QUrl("http://abc.org/foo.png"),
+            searchForResourceSearchPath(QUrl("http://abc.org"), QUrl("./foo.png"), {}));
+  EXPECT_EQ(QUrl("http://abc.org/foo.png"),
+            searchForResourceSearchPath(QUrl("http://abc.org"), QUrl("foo.png"), {}));
+
+  EXPECT_EQ(
+    QUrl("http://abc.org/x/y/foo.png"),
+    searchForResourceSearchPath(QUrl("http://abc.org/x/y/z"), QUrl("foo.png"), {}));
+  EXPECT_EQ(
+    QUrl("http://abc.org/foo.png"),
+    searchForResourceSearchPath(QUrl("http://abc.org/x/y/z"), QUrl("/foo.png"), {}));
+}
+
+TEST(UrlUtils, resolveResourceUrl_http_to_http)
+{
+  EXPECT_EQ(QUrl("http://xyz.com/foo.png"),
+            searchForResourceSearchPath(
+              QUrl("http://abc.org"), QUrl("http://xyz.com/foo.png"), {}));
+}
+
+TEST(UrlUtils, resolveResourceUrl_qrc_to_http)
+{
+  EXPECT_EQ(QUrl("qrc:assets/icons/foo.png"),
+            searchForResourceSearchPath(
+              QUrl("http://abc.org"), QUrl("qrc:assets/icons/foo.png"), {}));
+}
+
+TEST(UrlUtils, resolveResourceUrl_local_relative_to_qrc)
+{
+  EXPECT_EQ(QUrl("qrc:/qml/assets/icons/foo.png"),
+            searchForResourceSearchPath(
+              QUrl("qrc:/qml/myfile.qml"), QUrl("assets/icons/foo.png"), {}));
+  EXPECT_EQ(QUrl("qrc:/assets/icons/foo.png"),
+            searchForResourceSearchPath(
+              QUrl("qrc:/qml/myfile.qml"), QUrl("/assets/icons/foo.png"), {}));
+}
+
+TEST(UrlUtils, resolveResourceUrl_relative_local_to_local_dir)
+{
+  testWithSandbox([](QTemporaryDir& sandbox) {
+    auto temppath = sandbox.path() + "/";
+
+    QDir tempDir(temppath);
+    tempDir.mkpath(QLatin1String("assets"));
+
+    auto absPath = tempDir.absoluteFilePath("assets/a.css");
+    createFile(absPath);
+
+    EXPECT_EQ(QUrl::fromLocalFile(absPath),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(temppath), QUrl("./assets/a.css"), {}));
+    EXPECT_EQ(QUrl::fromLocalFile(absPath),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(temppath), QUrl("assets/a.css"), {}));
+  });
+}
+
+TEST(UrlUtils, resolveResourceUrl_relative_local_to_local_file)
+{
+  testWithSandbox([](QTemporaryDir& sandbox) {
+    auto temppath = sandbox.path() + "/";
+
+    QDir tempDir(temppath);
+    tempDir.mkpath(QLatin1String("assets"));
+
+    auto absPath = tempDir.absoluteFilePath("assets/a.css");
+    createFile(absPath);
+
+    auto localFilePath = QDir(temppath).absoluteFilePath("some.qml");
+
+    EXPECT_EQ(QUrl::fromLocalFile(absPath),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(localFilePath), QUrl("./assets/a.css"), {}));
+    EXPECT_EQ(QUrl::fromLocalFile(absPath),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(localFilePath), QUrl("assets/a.css"), {}));
+  });
+}
+
+TEST(UrlUtils, resolveResourceUrl_relative_local_with_search_path)
+{
+  testWithSandbox([](QTemporaryDir& sandbox) {
+    auto temppath = sandbox.path() + "/";
+
+    QDir tempDir(temppath);
+    tempDir.mkpath(QLatin1String("assets"));
+    auto absPath = tempDir.absoluteFilePath("assets/a.css");
+    createFile(absPath);
+
+    QDir fooTempDir(temppath);
+    fooTempDir.mkpath(QLatin1String("foo/assets"));
+    auto fooAbsPath = fooTempDir.absoluteFilePath("foo/assets/a.css");
+    createFile(fooAbsPath);
+
+    auto searchPath = QStringList{
+      tempDir.absoluteFilePath("foo/"), // this could match
+      tempDir.absoluteFilePath("bar/"),
+    };
+
+    // relative path not starting with "/" is not searched in path; if that is
+    // not valid "." return as-is
+    EXPECT_EQ(QUrl("assets/a.css"),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile("."), QUrl("assets/a.css"), searchPath));
+
+    // relative path not starting with "/" is not searched in path
+    auto localFilePath = QDir(temppath).absoluteFilePath("some.qml");
+    EXPECT_EQ(QUrl::fromLocalFile(absPath),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(localFilePath), QUrl("assets/a.css"), searchPath));
+
+    // relative path starting with "/" is looked up in search path, not resolved
+    // against baseurl
+    EXPECT_EQ(QUrl::fromLocalFile(fooAbsPath),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(localFilePath), QUrl("/assets/a.css"), searchPath));
+  });
+}
+
+TEST(UrlUtils, resolveResourceUrl_relative_dotdot_local_with_search_path)
+{
+  testWithSandbox([](QTemporaryDir& sandbox) {
+      auto temppath = sandbox.path() + "/";
+
+    QDir tempDir(temppath);
+    tempDir.mkpath(QLatin1String("assets"));
+    auto absPath = tempDir.absoluteFilePath("assets/a.css");
+    createFile(absPath);
+
+    QDir fooTempDir(temppath);
+    fooTempDir.mkpath(QLatin1String("foo/assets"));
+    auto fooAbsPath = fooTempDir.absoluteFilePath("foo/assets/a.css");
+    createFile(fooAbsPath);
+
+    auto searchPath = QStringList{
+      tempDir.absoluteFilePath("foo/xyz/"),
+      tempDir.absoluteFilePath("bar/")
+    };
+
+    // up-paths (../) are never resolved against search path
+    EXPECT_EQ(QUrl("../assets/a.css"),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile("."), QUrl("../assets/a.css"), searchPath));
+
+    auto localFilePath = QDir(temppath).absoluteFilePath("xyz/some.qml");
+    EXPECT_EQ(QUrl::fromLocalFile(absPath),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(localFilePath), QUrl("../assets/a.css"), searchPath));
+
+    // relative paths starting with '/' must not contain '/../'.  They are returned as-is.
+    EXPECT_EQ(QUrl(),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(localFilePath), QUrl("/../assets/a.css"), searchPath));
+
+    // path "/" fails
+    EXPECT_EQ(QUrl(),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile(localFilePath), QUrl("/"), searchPath));
+  });
+}
+
+TEST(UrlUtils, resolveResourceUrl_non_resolvable_url_is_returned_as_is)
+{
+  testWithSandbox([](QTemporaryDir& sandbox) {
+      auto temppath = sandbox.path() + "/";
+
+    QDir tempDir(temppath);
+    auto searchPath = QStringList{tempDir.absoluteFilePath("foo/"),
+                                  tempDir.absoluteFilePath("bar/"),
+                                  tempDir.absolutePath()};
+
+    EXPECT_EQ(QUrl("../assets/a.css"),
+              searchForResourceSearchPath(
+                QUrl::fromLocalFile("."), QUrl("../assets/a.css"), searchPath));
+  });
+}

--- a/tests/test-fonts.qml
+++ b/tests/test-fonts.qml
@@ -49,9 +49,8 @@ Item {
         }
 
         function test_missingFontsGivesAWarning() {
-            msgTracker.expectMessage(AqtTests.MsgTracker.Debug,
-                                     /^INFO:.*Load font face .*a-missing-font.ttf.*/);
-
+            msgTracker.expectMessage(AqtTests.MsgTracker.Warning,
+                                     /^WARN:.*Could not find font file.*a-missing-font.ttf.*/);
             compare(spy.count, 0);
 
             styleEngine.styleSheetSource = "missing-font.css"


### PR DESCRIPTION
The idea is to lookup local resources like fonts or icons in CSS files from a search path.  By default the search path is set to the `importPathList()` from the `QQmlEngine`.  In that way a font or icon can live near a QML file and being referenced relative to the QML file's folder, even if the CSS file is coming from somewhere else.

The previous strategy to lookup resources relative to a CSS's file location is kept as primary strategy though. I.e. the CSS's location is the first item in the search path.

@sbs-ableton @rof-ableton @dir-ableton