### PR TITLE
Make the fontIdCache owned by the StyleEngineHost

### DIFF
--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -69,6 +69,7 @@ void setGlobalStyleEngine(StyleEngine* pEngine)
 StyleEngine::StyleEngine(QObject* pParent)
   : QObject(pParent)
   , mChangeCount(0)
+  , mFontIdCache(StyleEngineHost::globalStyleEngineHost()->fontIdCache())
   , mStylesDir(this)
 {
   connect(&mFsWatcher, SIGNAL(fileChanged(const QString&)), this,
@@ -332,6 +333,11 @@ StyleEngineHost* StyleEngineHost::globalStyleEngineHost()
 StyleEngine* StyleEngineHost::globalStyleEngine()
 {
   return globalStyleEngineImpl();
+}
+
+StyleEngineHost::FontIdCache& StyleEngineHost::fontIdCache()
+{
+  return mFontIdCache;
 }
 
 QUrl StyleEngine::resolveResourceUrl(const QUrl& baseUrl, const QUrl& url) const

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -51,12 +51,19 @@ class StyleEngineHost : public QObject
 {
   Q_OBJECT
 public:
+  using FontIdCache = std::map<QString, int>;
+
   static StyleEngineHost* globalStyleEngineHost();
 
   static StyleEngine* globalStyleEngine();
 
+  FontIdCache& fontIdCache();
+
 Q_SIGNALS:
   void styleEngineLoaded(aqt::stylesheets::StyleEngine* pEngine);
+
+private:
+  std::map<QString, int> mFontIdCache;
 };
 
 /*! @endcond */
@@ -324,7 +331,7 @@ private:
   std::unique_ptr<IStyleMatchTree> mpStyleTree;
   QFileSystemWatcher mFsWatcher;
   int mChangeCount;
-  std::map<QString, int> mFontIdCache;
+  StyleEngineHost::FontIdCache& mFontIdCache;
 
   StylesDirWatcher mStylesDir;
 };


### PR DESCRIPTION
When using `qmltestrunner` to run QML unit tests, the QML engine is
destroyed and recreated.  This means that the `QFontDatabase` used by
the `StyleEngine` is also destroyed and recreated.  Unfortunately, the
`QFontDatabase` does not ask the window manager to remove fonts when it is
destroyed.  Therefore, if a `StyleEngine` has previously loaded a font,
and then tries to load the same font in the next test run, `QFontDatabase`
will call the OS-specific font loading code, which (at least on Mac OS)
will generate an error.

The solution here is to make the `fontIdCache` that the `StyleEngine` uses a
member of the `StyleEngineHost`, which is a singleton that is preserved
across destruction and recreation of the QML engine.  The `StyleEngine` thus
"knows" which fonts have previously been loaded, and will not try to load
them again.