### PR TITLE
Fix building with Qt5.5

### DIFF
--- a/src/test/LogUtils.cpp
+++ b/src/test/LogUtils.cpp
@@ -196,6 +196,10 @@ public:
       return LogTracker::kError;
     case QtFatalMsg:
       return LogTracker::kFatal;
+#if QT_VERSION >= 0x050500
+    case QtInfoMsg:
+      return LogTracker::kInfo;
+#endif
     }
 
     BOOST_ASSERT(false);


### PR DESCRIPTION
5.5 introduced the (missing) QtInfoMsg enum, we have to handle now.